### PR TITLE
Issue#197 : Add possibility to update build with ci build id.

### DIFF
--- a/src/builds/builds.controller.ts
+++ b/src/builds/builds.controller.ts
@@ -67,7 +67,7 @@ export class BuildsController {
   @ApiSecurity('api_key')
   @ApiBearerAuth()
   @UseGuards(MixedGuard)
-  update(@Param('id', new ParseUUIDPipe()) id: string,@Body() body: {}): Promise<BuildDto> {
+  update(@Param('id', new ParseUUIDPipe()) id: string, @Body() body: Record<string, unknown>): Promise<BuildDto> {
     return this.buildsService.update(id, body);
   }
 

--- a/src/builds/builds.controller.ts
+++ b/src/builds/builds.controller.ts
@@ -68,7 +68,11 @@ export class BuildsController {
   @ApiSecurity('api_key')
   @ApiBearerAuth()
   @UseGuards(MixedGuard)
-  update(@Param('id', new ParseUUIDPipe()) id: string, @Body() modifyBuildDto: ModifyBuildDto): Promise<BuildDto> {
+  update(@Param('id', new ParseUUIDPipe()) id: string, @Body() modifyBuildDto?: ModifyBuildDto): Promise<BuildDto> {
+    //In future, no or empty body will do nothing as this check will be removed. It will expect a proper body to perform any patch.
+    if (modifyBuildDto === null || Object.keys(modifyBuildDto).length === 0) {
+      modifyBuildDto.isRunning = false;
+    }
     return this.buildsService.update(id, modifyBuildDto);
   }
 

--- a/src/builds/builds.controller.ts
+++ b/src/builds/builds.controller.ts
@@ -25,7 +25,7 @@ import { PaginatedBuildDto } from './dto/build-paginated.dto';
 @Controller('builds')
 @ApiTags('builds')
 export class BuildsController {
-  constructor(private buildsService: BuildsService) {}
+  constructor(private buildsService: BuildsService) { }
 
   @Get()
   @ApiOkResponse({ type: PaginatedBuildDto })
@@ -67,8 +67,8 @@ export class BuildsController {
   @ApiSecurity('api_key')
   @ApiBearerAuth()
   @UseGuards(MixedGuard)
-  stop(@Param('id', new ParseUUIDPipe()) id: string): Promise<BuildDto> {
-    return this.buildsService.stop(id);
+  update(@Param('id', new ParseUUIDPipe()) id: string,@Body() body: {}): Promise<BuildDto> {
+    return this.buildsService.update(id, body);
   }
 
   @Patch(':id/approve')

--- a/src/builds/builds.controller.ts
+++ b/src/builds/builds.controller.ts
@@ -21,6 +21,7 @@ import { Build } from '@prisma/client';
 import { BuildDto } from './dto/build.dto';
 import { MixedGuard } from '../auth/guards/mixed.guard';
 import { PaginatedBuildDto } from './dto/build-paginated.dto';
+import { ModifyBuildDto } from './dto/build-modify.dto';
 
 @Controller('builds')
 @ApiTags('builds')
@@ -67,8 +68,8 @@ export class BuildsController {
   @ApiSecurity('api_key')
   @ApiBearerAuth()
   @UseGuards(MixedGuard)
-  update(@Param('id', new ParseUUIDPipe()) id: string, @Body() body: Record<string, unknown>): Promise<BuildDto> {
-    return this.buildsService.update(id, body);
+  update(@Param('id', new ParseUUIDPipe()) id: string, @Body() modifyBuildDto: ModifyBuildDto): Promise<BuildDto> {
+    return this.buildsService.update(id, modifyBuildDto);
   }
 
   @Patch(':id/approve')

--- a/src/builds/builds.service.spec.ts
+++ b/src/builds/builds.service.spec.ts
@@ -23,7 +23,6 @@ const initService = async ({
   testRunApproveMock = jest.fn(),
   eventsBuildUpdatedMock = jest.fn(),
   eventsBuildCreatedMock = jest.fn(),
-  eventsBuildFinishedMock = jest.fn(),
   projectFindOneMock = jest.fn(),
   projectUpdateMock = jest.fn(),
 }) => {
@@ -58,8 +57,7 @@ const initService = async ({
         provide: EventsGateway,
         useValue: {
           buildUpdated: eventsBuildUpdatedMock,
-          buildCreated: eventsBuildCreatedMock,
-          buildFinished: eventsBuildFinishedMock,
+          buildCreated: eventsBuildCreatedMock
         },
       },
       {
@@ -284,9 +282,9 @@ describe('BuildsService', () => {
   it('should stop', async () => {
     const id = 'some id';
     const buildUpdateMock = jest.fn();
-    const eventsBuildFinishedMock = jest.fn();
+    const eventsBuildUpdatedMock = jest.fn();
     mocked(BuildDto).mockReturnValueOnce(buildDto);
-    service = await initService({ buildUpdateMock, eventsBuildFinishedMock });
+    service = await initService({ buildUpdateMock, eventsBuildUpdatedMock });
 
     const result = await service.update(id, { "isRunning": false });
 
@@ -297,7 +295,7 @@ describe('BuildsService', () => {
       },
       data: { "isRunning": false }
     });
-    expect(eventsBuildFinishedMock).toHaveBeenCalledWith(buildDto);
+    expect(eventsBuildUpdatedMock).toHaveBeenCalledWith(buildDto);
     expect(result).toBe(buildDto);
   });
 

--- a/src/builds/builds.service.spec.ts
+++ b/src/builds/builds.service.spec.ts
@@ -288,16 +288,14 @@ describe('BuildsService', () => {
     mocked(BuildDto).mockReturnValueOnce(buildDto);
     service = await initService({ buildUpdateMock, eventsBuildFinishedMock });
 
-    const result = await service.stop(id);
+    const result = await service.update(id, { "isRunning": false });
 
     expect(buildUpdateMock).toHaveBeenCalledWith({
       where: { id },
       include: {
         testRuns: true,
       },
-      data: {
-        isRunning: false,
-      },
+      data: { "isRunning": false }
     });
     expect(eventsBuildFinishedMock).toHaveBeenCalledWith(buildDto);
     expect(result).toBe(buildDto);

--- a/src/builds/builds.service.ts
+++ b/src/builds/builds.service.ts
@@ -1,12 +1,13 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { CreateBuildDto } from './dto/build-create.dto';
 import { PrismaService } from '../prisma/prisma.service';
-import { Build, Prisma, TestStatus } from '@prisma/client';
+import { Build, TestStatus } from '@prisma/client';
 import { TestRunsService } from '../test-runs/test-runs.service';
 import { EventsGateway } from '../shared/events/events.gateway';
 import { BuildDto } from './dto/build.dto';
 import { ProjectsService } from '../projects/projects.service';
 import { PaginatedBuildDto } from './dto/build-paginated.dto';
+import { ModifyBuildDto } from './dto/build-modify.dto';
 
 @Injectable()
 export class BuildsService {
@@ -99,13 +100,13 @@ export class BuildsService {
     return new BuildDto(build);
   }
 
-  async update(id: string, body: Record<string, unknown>): Promise<BuildDto> {
+  async update(id: string, modifyBuildDto: ModifyBuildDto): Promise<BuildDto> {
     const build = await this.prismaService.build.update({
       where: { id },
       include: {
         testRuns: true,
       },
-      data: body as Prisma.BuildUpdateInput
+      data: modifyBuildDto
     });
     const buildDto = new BuildDto(build);
     this.eventsGateway.buildUpdated(buildDto);

--- a/src/builds/builds.service.ts
+++ b/src/builds/builds.service.ts
@@ -99,7 +99,7 @@ export class BuildsService {
     return new BuildDto(build);
   }
 
-  async update(id: string, body: {}): Promise<BuildDto> {
+  async update(id: string, body: Record<string, unknown>): Promise<BuildDto> {
     const build = await this.prismaService.build.update({
       where: { id },
       include: {
@@ -108,9 +108,7 @@ export class BuildsService {
       data: body as Prisma.BuildUpdateInput
     });
     const buildDto = new BuildDto(build);
-    if(!buildDto.isRunning){
-      this.eventsGateway.buildFinished(buildDto);
-    }
+    this.eventsGateway.buildUpdated(buildDto);
     return buildDto;
   }
 

--- a/src/builds/builds.service.ts
+++ b/src/builds/builds.service.ts
@@ -1,7 +1,7 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { CreateBuildDto } from './dto/build-create.dto';
 import { PrismaService } from '../prisma/prisma.service';
-import { Build, TestStatus } from '@prisma/client';
+import { Build, Prisma, TestStatus } from '@prisma/client';
 import { TestRunsService } from '../test-runs/test-runs.service';
 import { EventsGateway } from '../shared/events/events.gateway';
 import { BuildDto } from './dto/build.dto';
@@ -17,7 +17,7 @@ export class BuildsService {
     private testRunsService: TestRunsService,
     @Inject(forwardRef(() => ProjectsService))
     private projectService: ProjectsService
-  ) {}
+  ) { }
 
   async findOne(id: string): Promise<BuildDto> {
     return this.prismaService.build
@@ -99,18 +99,18 @@ export class BuildsService {
     return new BuildDto(build);
   }
 
-  async stop(id: string): Promise<BuildDto> {
+  async update(id: string, body: {}): Promise<BuildDto> {
     const build = await this.prismaService.build.update({
       where: { id },
       include: {
         testRuns: true,
       },
-      data: {
-        isRunning: false,
-      },
+      data: body as Prisma.BuildUpdateInput
     });
     const buildDto = new BuildDto(build);
-    this.eventsGateway.buildFinished(buildDto);
+    if(!buildDto.isRunning){
+      this.eventsGateway.buildFinished(buildDto);
+    }
     return buildDto;
   }
 

--- a/src/builds/dto/build-modify.dto.ts
+++ b/src/builds/dto/build-modify.dto.ts
@@ -1,0 +1,4 @@
+export interface ModifyBuildDto {
+    ciBuildId?: string;
+    isRunning?: boolean;
+}

--- a/src/shared/events/events.gateway.ts
+++ b/src/shared/events/events.gateway.ts
@@ -12,10 +12,6 @@ export class EventsGateway {
     this.server.emit('build_created', build);
   }
 
-  buildFinished(build: BuildDto): void {
-    this.server.emit('build_finished', build);
-  }
-
   buildUpdated(build: BuildDto): void {
     this.server.emit('build_updated', build);
   }

--- a/src/test-variations/test-variations.service.spec.ts
+++ b/src/test-variations/test-variations.service.spec.ts
@@ -22,7 +22,7 @@ const initModule = async ({
   baselineDeleteMock = jest.fn(),
   projectFindUniqueMock = jest.fn(),
   buildCreateMock = jest.fn(),
-  buildStopMock = jest.fn(),
+  buildUpdateMock = jest.fn(),
   testRunCreateMock = jest.fn(),
   testRunFindMany = jest.fn(),
   testRunDeleteMock = jest.fn(),
@@ -41,7 +41,7 @@ const initModule = async ({
         provide: BuildsService,
         useValue: {
           create: buildCreateMock,
-          stop: buildStopMock,
+          update: buildUpdateMock,
         },
       },
       {
@@ -417,11 +417,11 @@ describe('TestVariationsService', () => {
       .mockResolvedValueOnce(testVariationMainBranch)
       .mockResolvedValueOnce(testVariationMainBranch);
     const testRunCreateMock = jest.fn();
-    const buildStopMock = jest.fn();
+    const buildUpdateMock = jest.fn();
     const service = await initModule({
       projectFindUniqueMock,
       buildCreateMock,
-      buildStopMock,
+      buildUpdateMock,
       testRunCreateMock,
       variationFindManyMock,
       getImageMock,
@@ -466,7 +466,7 @@ describe('TestVariationsService', () => {
       ignoreAreas: JSON.parse(testVariationSecond.ignoreAreas),
     });
     expect(testRunCreateMock).toHaveBeenCalledTimes(2);
-    expect(buildStopMock).toHaveBeenCalledWith(build.id);
+    expect(buildUpdateMock).toHaveBeenCalledWith(build.id, { "isRunning": false });
   });
 
   it('delete', async () => {

--- a/src/test-variations/test-variations.service.ts
+++ b/src/test-variations/test-variations.service.ts
@@ -21,7 +21,7 @@ export class TestVariationsService {
     private testRunsService: TestRunsService,
     @Inject(forwardRef(() => BuildsService))
     private buildsService: BuildsService
-  ) {}
+  ) { }
 
   async getDetails(id: string): Promise<TestVariation & { baselines: Baseline[] }> {
     return this.prismaService.testVariation.findUnique({
@@ -138,7 +138,7 @@ export class TestVariationsService {
     });
 
     // stop build
-    return this.buildsService.stop(build.id);
+    return this.buildsService.update(build.id, { "isRunning": false });
   }
 
   async delete(id: string): Promise<TestVariation> {


### PR DESCRIPTION
Addresses https://github.com/Visual-Regression-Tracker/Visual-Regression-Tracker/issues/197 
Made generic method to modify a build. This method can be used both for stopping or modifying any other feature (like CI build id) of the build. Corresponding frontend changes will also be raised as a pull request.