### PR TITLE
feature(diff): getDiff even on dimensions missmatch

### DIFF
--- a/src/test-runs/test-runs.service.spec.ts
+++ b/src/test-runs/test-runs.service.spec.ts
@@ -15,8 +15,9 @@ import { TestVariationsService } from '../test-variations/test-variations.servic
 import { convertBaselineDataToQuery } from '../shared/dto/baseline-data.dto';
 import { TestRunDto } from './dto/testRun.dto';
 import { BuildsService } from '../builds/builds.service';
+import fs from 'fs';
 
-jest.mock('pixelmatch');
+// jest.mock('pixelmatch');
 jest.mock('./dto/testRunResult.dto');
 
 const initService = async ({
@@ -99,6 +100,21 @@ const initService = async ({
 
   return module.get<TestRunsService>(TestRunsService);
 };
+
+const fillPng = (png, r,g,b, pixelsCount = 0, alpha=255) => {
+  for (let y = 0; y < png.height; y++) {
+    for (let x = 0; x < png.width; x++) {
+      const idx = (png.width * y + x) << 2;
+      if (pixelsCount === 0 || idx < pixelsCount*4) {
+        png.data[idx] = r;
+        png.data[idx+1] = g;
+        png.data[idx+2] = b;
+        png.data[idx+3] = alpha;
+      }
+    }
+  }
+}
+
 describe('TestRunsService', () => {
   let service: TestRunsService;
   const ignoreAreas = [{ x: 1, y: 2, width: 10, height: 20 }];
@@ -603,7 +619,8 @@ describe('TestRunsService', () => {
       });
     });
 
-    it('diff image dimensions mismatch', async () => {
+    it('diff image dimensions mismatch ', async () => {
+
       const baseline = new PNG({
         width: 10,
         height: 10,
@@ -612,15 +629,19 @@ describe('TestRunsService', () => {
         width: 20,
         height: 20,
       });
-      service = await initService({});
+      fillPng(baseline, 0, 0, 0)
+      fillPng(image, 0, 0, 0)
+      const saveImageMock = jest.fn();
+      service = await initService({saveImageMock});
 
       const result = service.getDiff(baseline, image, baseTestRun);
 
+      expect(saveImageMock).toHaveBeenCalledTimes(1);
       expect(result).toStrictEqual({
         status: TestStatus.unresolved,
-        diffName: null,
-        pixelMisMatchCount: undefined,
-        diffPercent: undefined,
+        diffName: undefined,
+        pixelMisMatchCount: 20*20 - 10*10,
+        diffPercent: 75,
         isSameDimension: false,
       });
     });
@@ -634,8 +655,10 @@ describe('TestRunsService', () => {
         width: 10,
         height: 10,
       });
+      fillPng(baseline, 0, 0, 0)
+      fillPng(image, 0, 0, 0)
       service = await initService({});
-      mocked(Pixelmatch).mockReturnValueOnce(0);
+      // mocked(Pixelmatch).mockReturnValueOnce(0);
 
       const result = service.getDiff(baseline, image, baseTestRun);
 
@@ -663,10 +686,18 @@ describe('TestRunsService', () => {
         width: 100,
         height: 100,
       });
+      fillPng(baseline, 0, 0, 0)
+      fillPng(image, 0, 0, 0)
+      await baseline.pack().pipe(fs.createWriteStream('image1.png'))
+
+      const pixelMisMatchCount = 150;
+      fillPng(image, 255,0,0, pixelMisMatchCount)
+
+      await image.pack().pipe(fs.createWriteStream('image2.png'))
       const saveImageMock = jest.fn();
       service = await initService({ saveImageMock });
-      const pixelMisMatchCount = 150;
-      mocked(Pixelmatch).mockReturnValueOnce(pixelMisMatchCount);
+
+      // mocked(Pixelmatch).mockReturnValueOnce(pixelMisMatchCount);
 
       const result = service.getDiff(baseline, image, testRun);
 
@@ -695,8 +726,11 @@ describe('TestRunsService', () => {
         width: 100,
         height: 100,
       });
+      fillPng(baseline, 0, 0, 0, 255)
+      fillPng(image, 0, 0, 0, 255)
       const pixelMisMatchCount = 200;
-      mocked(Pixelmatch).mockReturnValueOnce(pixelMisMatchCount);
+      fillPng(image, 255,0,0,pixelMisMatchCount)
+      // mocked(Pixelmatch).mockReturnValueOnce(pixelMisMatchCount);
       const diffName = 'diff name';
       const saveImageMock = jest.fn().mockReturnValueOnce(diffName);
       service = await initService({

--- a/src/test-runs/test-runs.service.spec.ts
+++ b/src/test-runs/test-runs.service.spec.ts
@@ -99,6 +99,7 @@ const initService = async ({
   return module.get<TestRunsService>(TestRunsService);
 };
 
+// Helper fills PNG with specified color, or fills number of pixels in png if specified
 const fillPng = (png, r, g, b, pixelsCount = 0, alpha = 255) => {
   for (let y = 0; y < png.height; y++) {
     for (let x = 0; x < png.width; x++) {

--- a/src/test-runs/test-runs.service.spec.ts
+++ b/src/test-runs/test-runs.service.spec.ts
@@ -5,7 +5,6 @@ import { PrismaService } from '../prisma/prisma.service';
 import { StaticService } from '../shared/static/static.service';
 import { PNG } from 'pngjs';
 import { TestStatus, TestRun, TestVariation } from '@prisma/client';
-import Pixelmatch from 'pixelmatch';
 import { CreateTestRequestDto } from './dto/create-test-request.dto';
 import { TestRunResultDto } from './dto/testRunResult.dto';
 import { DiffResult } from './diffResult';
@@ -15,7 +14,6 @@ import { TestVariationsService } from '../test-variations/test-variations.servic
 import { convertBaselineDataToQuery } from '../shared/dto/baseline-data.dto';
 import { TestRunDto } from './dto/testRun.dto';
 import { BuildsService } from '../builds/builds.service';
-import fs from 'fs';
 
 // jest.mock('pixelmatch');
 jest.mock('./dto/testRunResult.dto');
@@ -101,19 +99,19 @@ const initService = async ({
   return module.get<TestRunsService>(TestRunsService);
 };
 
-const fillPng = (png, r,g,b, pixelsCount = 0, alpha=255) => {
+const fillPng = (png, r, g, b, pixelsCount = 0, alpha = 255) => {
   for (let y = 0; y < png.height; y++) {
     for (let x = 0; x < png.width; x++) {
       const idx = (png.width * y + x) << 2;
-      if (pixelsCount === 0 || idx < pixelsCount*4) {
+      if (pixelsCount === 0 || idx < pixelsCount * 4) {
         png.data[idx] = r;
-        png.data[idx+1] = g;
-        png.data[idx+2] = b;
-        png.data[idx+3] = alpha;
+        png.data[idx + 1] = g;
+        png.data[idx + 2] = b;
+        png.data[idx + 3] = alpha;
       }
     }
   }
-}
+};
 
 describe('TestRunsService', () => {
   let service: TestRunsService;
@@ -620,7 +618,6 @@ describe('TestRunsService', () => {
     });
 
     it('diff image dimensions mismatch ', async () => {
-
       const baseline = new PNG({
         width: 10,
         height: 10,
@@ -629,18 +626,20 @@ describe('TestRunsService', () => {
         width: 20,
         height: 20,
       });
-      fillPng(baseline, 0, 0, 0)
-      fillPng(image, 0, 0, 0)
-      const saveImageMock = jest.fn();
-      service = await initService({saveImageMock});
+      fillPng(baseline, 0, 0, 0);
+      fillPng(image, 0, 0, 0);
+
+      const diffName = 'diff name';
+      const saveImageMock = jest.fn().mockReturnValueOnce(diffName);
+      service = await initService({ saveImageMock });
 
       const result = service.getDiff(baseline, image, baseTestRun);
 
       expect(saveImageMock).toHaveBeenCalledTimes(1);
       expect(result).toStrictEqual({
         status: TestStatus.unresolved,
-        diffName: undefined,
-        pixelMisMatchCount: 20*20 - 10*10,
+        diffName,
+        pixelMisMatchCount: 20 * 20 - 10 * 10,
         diffPercent: 75,
         isSameDimension: false,
       });
@@ -655,10 +654,9 @@ describe('TestRunsService', () => {
         width: 10,
         height: 10,
       });
-      fillPng(baseline, 0, 0, 0)
-      fillPng(image, 0, 0, 0)
+      fillPng(baseline, 0, 0, 0);
+      fillPng(image, 0, 0, 0);
       service = await initService({});
-      // mocked(Pixelmatch).mockReturnValueOnce(0);
 
       const result = service.getDiff(baseline, image, baseTestRun);
 
@@ -686,18 +684,14 @@ describe('TestRunsService', () => {
         width: 100,
         height: 100,
       });
-      fillPng(baseline, 0, 0, 0)
-      fillPng(image, 0, 0, 0)
-      await baseline.pack().pipe(fs.createWriteStream('image1.png'))
+      fillPng(baseline, 0, 0, 0);
+      fillPng(image, 0, 0, 0);
 
       const pixelMisMatchCount = 150;
-      fillPng(image, 255,0,0, pixelMisMatchCount)
+      fillPng(image, 255, 0, 0, pixelMisMatchCount);
 
-      await image.pack().pipe(fs.createWriteStream('image2.png'))
       const saveImageMock = jest.fn();
       service = await initService({ saveImageMock });
-
-      // mocked(Pixelmatch).mockReturnValueOnce(pixelMisMatchCount);
 
       const result = service.getDiff(baseline, image, testRun);
 
@@ -726,11 +720,11 @@ describe('TestRunsService', () => {
         width: 100,
         height: 100,
       });
-      fillPng(baseline, 0, 0, 0, 255)
-      fillPng(image, 0, 0, 0, 255)
+      fillPng(baseline, 0, 0, 0, 255);
+      fillPng(image, 0, 0, 0, 255);
       const pixelMisMatchCount = 200;
-      fillPng(image, 255,0,0,pixelMisMatchCount)
-      // mocked(Pixelmatch).mockReturnValueOnce(pixelMisMatchCount);
+      fillPng(image, 255, 0, 0, pixelMisMatchCount);
+
       const diffName = 'diff name';
       const saveImageMock = jest.fn().mockReturnValueOnce(diffName);
       service = await initService({

--- a/src/test-runs/test-runs.service.ts
+++ b/src/test-runs/test-runs.service.ts
@@ -272,9 +272,8 @@ export class TestRunsService {
   }
 
   prepareImage(image: PNG, width: number, height: number) {
-    let preparedImage;
     if (width > image.width || height > image.height) {
-      preparedImage = new PNG({ width, height, fill: true });
+      const preparedImage = new PNG({ width, height, fill: true });
       PNG.bitblt(image, preparedImage, 0, 0, image.width, image.height, 0, 0);
       return preparedImage;
     } else {

--- a/src/test-runs/test-runs.service.ts
+++ b/src/test-runs/test-runs.service.ts
@@ -272,13 +272,13 @@ export class TestRunsService {
   }
 
   prepareImage(image: PNG, width: number, height: number) {
-    let preparedImage
+    let preparedImage;
     if (width > image.width || height > image.height) {
-      preparedImage = new PNG({width, height, fill: true})
-      PNG.bitblt(image, preparedImage, 0, 0, image.width, image.height, 0, 0)
-      return  preparedImage
+      preparedImage = new PNG({ width, height, fill: true });
+      PNG.bitblt(image, preparedImage, 0, 0, image.width, image.height, 0, 0);
+      return preparedImage;
     } else {
-      return image
+      return image;
     }
   }
 
@@ -294,40 +294,39 @@ export class TestRunsService {
     if (baseline) {
       result.isSameDimension = baseline.width === image.width && baseline.height === image.height;
 
-      const width = Math.max(baseline.width, image.width)
-      const height = Math.max(baseline.height, image.height)
+      const width = Math.max(baseline.width, image.width);
+      const height = Math.max(baseline.height, image.height);
 
-      const prepearedBaseline = this.prepareImage(baseline, width, height)
-      const preparedImage = this.prepareImage(image, width, height)
-
+      const prepearedBaseline = this.prepareImage(baseline, width, height);
+      const preparedImage = this.prepareImage(image, width, height);
 
       // if (result.isSameDimension) {
-        const diff = new PNG({
-          width,
-          height,
-        });
+      const diff = new PNG({
+        width,
+        height,
+      });
 
-        const ignoreAreas = this.getIgnoteAreas(testRun);
-        // compare
-        result.pixelMisMatchCount = Pixelmatch(
-          this.applyIgnoreAreas(prepearedBaseline, ignoreAreas),
-          this.applyIgnoreAreas(preparedImage, ignoreAreas),
-          diff.data,
-          width,
-          height,
-          {
-            includeAA: true,
-          }
-        );
-        result.diffPercent = (result.pixelMisMatchCount * 100) / (image.width * image.height);
-
-        if (result.diffPercent > testRun.diffTollerancePercent) {
-          // save diff
-          result.diffName = this.staticService.saveImage('diff', PNG.sync.write(diff));
-          result.status = TestStatus.unresolved;
-        } else {
-          result.status = TestStatus.ok;
+      const ignoreAreas = this.getIgnoteAreas(testRun);
+      // compare
+      result.pixelMisMatchCount = Pixelmatch(
+        this.applyIgnoreAreas(prepearedBaseline, ignoreAreas),
+        this.applyIgnoreAreas(preparedImage, ignoreAreas),
+        diff.data,
+        width,
+        height,
+        {
+          includeAA: true,
         }
+      );
+      result.diffPercent = (result.pixelMisMatchCount * 100) / (image.width * image.height);
+
+      if (result.diffPercent > testRun.diffTollerancePercent) {
+        // save diff
+        result.diffName = this.staticService.saveImage('diff', PNG.sync.write(diff));
+        result.status = TestStatus.unresolved;
+      } else {
+        result.status = TestStatus.ok;
+      }
       // } else {
       //   // diff dimensions
       //   result.status = TestStatus.unresolved;


### PR DESCRIPTION
Adds feature https://github.com/Visual-Regression-Tracker/Visual-Regression-Tracker/issues/237

Adds empty area on smaller image before diff.

Real pixelmatch in getDiff test. fillPng helper for generating test png.