### PR TITLE
Added capability to fetch user log from Elastic.

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,8 @@ BODY_PARSER_JSON_LIMIT="5mb"
 APP_PORT=4200
 APP_FRONTEND_URL=http://localhost:8080
 
+ELASTIC_URL=http://localhost:9200
+
 # docker
 POSTGRES_PORT=5432
 POSTGRES_USER=postgres

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core';
 import { HttpExceptionFilter } from './http-exception.filter';
 import { CompareModule } from './compare/compare.module';
 import { ScheduleModule } from '@nestjs/schedule';
+import { UserLogsModule } from './shared/user-logs/user-logs.module';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { ScheduleModule } from '@nestjs/schedule';
     TestRunsModule,
     TestVariationsModule,
     CompareModule,
+    UserLogsModule
   ],
   providers: [
     PrismaService,

--- a/src/builds/builds.controller.spec.ts
+++ b/src/builds/builds.controller.spec.ts
@@ -10,6 +10,7 @@ import { Build } from '.prisma/client';
 import { BuildDto } from './dto/build.dto';
 import { CreateBuildDto } from './dto/build-create.dto';
 import { EventsGateway } from '../shared/events/events.gateway';
+import { VRTUserLogService } from '../shared/user-logs/user-log.service';
 
 const initController = async ({
   projectFindOneMock = jest.fn(),
@@ -37,6 +38,7 @@ const initController = async ({
       },
       { provide: EventsGateway, useValue: { buildCreated: eventBuildCreatedMock } },
       { provide: PrismaService, useValue: {} },
+      { provide: VRTUserLogService, useValue: {} },
       { provide: ApiGuard, useValue: {} },
       { provide: JwtAuthGuard, useValue: {} },
     ],

--- a/src/builds/builds.controller.ts
+++ b/src/builds/builds.controller.ts
@@ -28,7 +28,7 @@ import { ModifyBuildDto } from './dto/build-modify.dto';
 import { ProjectsService } from '../projects/projects.service';
 import { RoleGuard } from '../auth/guards/role.guard';
 import { Roles } from '../shared/roles.decorator';
-import { UserLogInterceptor } from 'src/shared/user-logs/user-log-interceptor';
+import { UserLogInterceptor } from '../shared/user-logs/user-log-interceptor';
 
 @Controller('builds')
 @ApiTags('builds')

--- a/src/builds/builds.controller.ts
+++ b/src/builds/builds.controller.ts
@@ -13,6 +13,7 @@ import {
   ParseBoolPipe,
   forwardRef,
   Inject,
+  UseInterceptors,
 } from '@nestjs/common';
 import { BuildsService } from './builds.service';
 import { JwtAuthGuard } from '../auth/guards/auth.guard';
@@ -27,6 +28,7 @@ import { ModifyBuildDto } from './dto/build-modify.dto';
 import { ProjectsService } from '../projects/projects.service';
 import { RoleGuard } from '../auth/guards/role.guard';
 import { Roles } from '../shared/roles.decorator';
+import { UserLogInterceptor } from 'src/shared/user-logs/user-log-interceptor';
 
 @Controller('builds')
 @ApiTags('builds')
@@ -61,6 +63,7 @@ export class BuildsController {
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard, RoleGuard)
   @Roles(Role.admin, Role.editor)
+  @UseInterceptors(UserLogInterceptor)
   remove(@Param('id', new ParseUUIDPipe()) id: string): Promise<Build> {
     return this.buildsService.remove(id);
   }
@@ -70,6 +73,7 @@ export class BuildsController {
   @ApiSecurity('api_key')
   @UseGuards(ApiGuard, RoleGuard)
   @Roles(Role.admin, Role.editor)
+  @UseInterceptors(UserLogInterceptor)
   async create(@Body() createBuildDto: CreateBuildDto): Promise<BuildDto> {
     const project = await this.projectService.findOne(createBuildDto.project);
     await this.buildsService.deleteOldBuilds(project.id, project.maxBuildAllowed);

--- a/src/builds/builds.module.ts
+++ b/src/builds/builds.module.ts
@@ -1,4 +1,4 @@
-import { forwardRef, Module } from '@nestjs/common';
+import { forwardRef, HttpModule, Module } from '@nestjs/common';
 import { BuildsService } from './builds.service';
 import { BuildsController } from './builds.controller';
 import { UsersModule } from '../users/users.module';
@@ -7,11 +7,12 @@ import { TestRunsModule } from '../test-runs/test-runs.module';
 import { SharedModule } from '../shared/shared.module';
 import { AuthModule } from '../auth/auth.module';
 import { ProjectsModule } from '../projects/projects.module';
+import { VRTUserLogService } from 'src/shared/user-logs/user-log.service';
 
 @Module({
-  imports: [SharedModule, UsersModule, forwardRef(() => TestRunsModule), AuthModule, forwardRef(() => ProjectsModule)],
-  providers: [BuildsService, PrismaService],
+  imports: [SharedModule, UsersModule, forwardRef(() => TestRunsModule), AuthModule, forwardRef(() => ProjectsModule), HttpModule],
+  providers: [BuildsService, PrismaService, VRTUserLogService],
   controllers: [BuildsController],
   exports: [BuildsService],
 })
-export class BuildsModule {}
+export class BuildsModule { }

--- a/src/builds/builds.module.ts
+++ b/src/builds/builds.module.ts
@@ -7,7 +7,7 @@ import { TestRunsModule } from '../test-runs/test-runs.module';
 import { SharedModule } from '../shared/shared.module';
 import { AuthModule } from '../auth/auth.module';
 import { ProjectsModule } from '../projects/projects.module';
-import { VRTUserLogService } from 'src/shared/user-logs/user-log.service';
+import { VRTUserLogService } from '../shared/user-logs/user-log.service';
 
 @Module({
   imports: [SharedModule, UsersModule, forwardRef(() => TestRunsModule), AuthModule, forwardRef(() => ProjectsModule), HttpModule],

--- a/src/http-exception.filter.ts
+++ b/src/http-exception.filter.ts
@@ -9,14 +9,14 @@ export class HttpExceptionFilter implements ExceptionFilter {
     const request = ctx.getRequest<Request>();
 
     let status: number;
-    const isUniqueConstaintException = this.isUniqueConstraintException(exception);
+    const isUniqueConstraintException = this.isUniqueConstraintException(exception);
     const isForbiddenException = this.isForbiddenException(exception);
     try {
-      status = isUniqueConstaintException ? HttpStatus.BAD_REQUEST : exception.getStatus();
+      status = isUniqueConstraintException ? HttpStatus.BAD_REQUEST : exception.getStatus();
     } catch {
       status = HttpStatus.INTERNAL_SERVER_ERROR;
     }
-    const message = (isUniqueConstaintException || isForbiddenException) ? this.getCustomMessageForException(exception) : exception.message;
+    const message = (isUniqueConstraintException || isForbiddenException) ? this.getCustomMessageForException(exception) : exception.message;
 
     Logger.error(exception, exception.stack);
 

--- a/src/projects/projects.controller.spec.ts
+++ b/src/projects/projects.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { VRTUserLogService } from '../shared/user-logs/user-log.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { ProjectsController } from './projects.controller';
 import { ProjectsService } from './projects.service';
@@ -12,6 +13,7 @@ describe('Projects Controller', () => {
       providers: [
         { provide: ProjectsService, useValue: {} },
         { provide: PrismaService, useValue: {} },
+        { provide: VRTUserLogService, useValue: {} },
       ],
     }).compile();
 

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -8,7 +8,7 @@ import { ProjectDto } from './dto/project.dto';
 import { UpdateProjectDto } from './dto/update-project.dto';
 import { RoleGuard } from '../auth/guards/role.guard';
 import { Roles } from '../shared/roles.decorator';
-import { UserLogInterceptor } from 'src/shared/user-logs/user-log-interceptor';
+import { UserLogInterceptor } from '../shared/user-logs/user-log-interceptor';
 
 @Controller('projects')
 @ApiTags('projects')

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, UseGuards, Body, Post, Param, ParseUUIDPipe, Delete, Put } from '@nestjs/common';
+import { Controller, Get, UseGuards, Body, Post, Param, ParseUUIDPipe, Delete, Put, UseInterceptors } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOkResponse, ApiParam } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/auth.guard';
 import { ProjectsService } from './projects.service';
@@ -8,6 +8,7 @@ import { ProjectDto } from './dto/project.dto';
 import { UpdateProjectDto } from './dto/update-project.dto';
 import { RoleGuard } from '../auth/guards/role.guard';
 import { Roles } from '../shared/roles.decorator';
+import { UserLogInterceptor } from 'src/shared/user-logs/user-log-interceptor';
 
 @Controller('projects')
 @ApiTags('projects')
@@ -27,6 +28,7 @@ export class ProjectsController {
   @UseGuards(JwtAuthGuard, RoleGuard)
   @Roles(Role.admin, Role.editor)
   @ApiOkResponse({ type: ProjectDto })
+  @UseInterceptors(UserLogInterceptor)
   create(@Body() createProjectDto: CreateProjectDto): Promise<Project> {
     return this.projectsService.create(createProjectDto);
   }
@@ -36,6 +38,7 @@ export class ProjectsController {
   @UseGuards(JwtAuthGuard, RoleGuard)
   @Roles(Role.admin, Role.editor)
   @ApiOkResponse({ type: ProjectDto })
+  @UseInterceptors(UserLogInterceptor)
   update(@Body() projectDto: UpdateProjectDto): Promise<Project> {
     return this.projectsService.update(projectDto);
   }
@@ -46,6 +49,7 @@ export class ProjectsController {
   @Roles(Role.admin, Role.editor)
   @ApiOkResponse({ type: ProjectDto })
   @ApiParam({ name: 'id', required: true })
+  @UseInterceptors(UserLogInterceptor)
   remove(@Param('id', new ParseUUIDPipe()) id: string): Promise<Project> {
     return this.projectsService.remove(id);
   }

--- a/src/projects/projects.module.ts
+++ b/src/projects/projects.module.ts
@@ -4,7 +4,7 @@ import { ProjectsController } from './projects.controller';
 import { BuildsModule } from '../builds/builds.module';
 import { TestVariationsModule } from '../test-variations/test-variations.module';
 import { PrismaService } from '../prisma/prisma.service';
-import { VRTUserLogService } from 'src/shared/user-logs/user-log.service';
+import { VRTUserLogService } from '../shared/user-logs/user-log.service';
 
 @Module({
   imports: [forwardRef(() => BuildsModule), forwardRef(() => TestVariationsModule), HttpModule],

--- a/src/projects/projects.module.ts
+++ b/src/projects/projects.module.ts
@@ -1,14 +1,15 @@
-import { forwardRef, Module } from '@nestjs/common';
+import { forwardRef, HttpModule, Module } from '@nestjs/common';
 import { ProjectsService } from './projects.service';
 import { ProjectsController } from './projects.controller';
 import { BuildsModule } from '../builds/builds.module';
 import { TestVariationsModule } from '../test-variations/test-variations.module';
 import { PrismaService } from '../prisma/prisma.service';
+import { VRTUserLogService } from 'src/shared/user-logs/user-log.service';
 
 @Module({
-  imports: [forwardRef(() => BuildsModule), forwardRef(() => TestVariationsModule)],
-  providers: [ProjectsService, PrismaService],
+  imports: [forwardRef(() => BuildsModule), forwardRef(() => TestVariationsModule), HttpModule],
+  providers: [ProjectsService, PrismaService, VRTUserLogService],
   controllers: [ProjectsController],
   exports: [ProjectsService],
 })
-export class ProjectsModule {}
+export class ProjectsModule { }

--- a/src/shared/shared.module.ts
+++ b/src/shared/shared.module.ts
@@ -1,15 +1,16 @@
-import { forwardRef, Global, Module } from '@nestjs/common';
+import { forwardRef, Global, HttpModule, Module } from '@nestjs/common';
 import { StaticService } from './static/static.service';
 import { EventsGateway } from '../shared/events/events.gateway';
 import { PrismaService } from '../prisma/prisma.service';
 import { TasksService } from './tasks/tasks.service';
 import { TestVariationsModule } from '../test-variations/test-variations.module';
+import { VRTUserLogService } from './user-logs/user-log.service';
 
 @Global()
 @Module({
-  providers: [StaticService, EventsGateway, PrismaService, TasksService],
+  providers: [StaticService, EventsGateway, PrismaService, TasksService, VRTUserLogService],
   exports: [StaticService, EventsGateway, PrismaService],
-  imports: [forwardRef(() => TestVariationsModule)],
+  imports: [forwardRef(() => TestVariationsModule), HttpModule],
   controllers: [],
 })
-export class SharedModule {}
+export class SharedModule { }

--- a/src/shared/user-logs/user-log-interceptor.ts
+++ b/src/shared/user-logs/user-log-interceptor.ts
@@ -1,0 +1,39 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from "@nestjs/common";
+import { Observable } from "rxjs";
+import { tap } from 'rxjs/operators';
+import { VRTUserLogService } from "./user-log.service";
+
+@Injectable()
+export class UserLogInterceptor implements NestInterceptor {
+
+    constructor(private logService: VRTUserLogService) { }
+
+    async intercept(context: ExecutionContext, next: CallHandler): Promise<Observable<any>> {
+        const request: Request = context.switchToHttp().getRequest();
+        const response: any = context.switchToHttp().getResponse();
+        let description: string;
+        //When we delete an entry from database, it is important to collect information before deleting so that we can log it properly.
+        if (request.method.includes('DELETE') || this.isTestRunDelete(request)) {
+            description = await this.logService.getLogDescriptionBeforeDeletingFromDB('', request);
+        }
+        return next
+            .handle()
+            .pipe(
+                tap(() => {
+                    if (this.isResponseSuccessful(response)) {
+                        //Description will be recreated in logService if it is undefined.
+                        this.logService.postData(request, description);
+                    }
+                }),
+            );
+    }
+
+    private isTestRunDelete(request: Request): boolean {
+        return request.url.includes('test-runs/delete') && request.method.includes('POST');
+    }
+
+    private isResponseSuccessful(response: any) {
+        return response.statusCode >= 200 && response.statusCode < 300
+    }
+
+}

--- a/src/shared/user-logs/user-log.service.ts
+++ b/src/shared/user-logs/user-log.service.ts
@@ -1,7 +1,7 @@
 import { HttpService, Injectable, Logger } from "@nestjs/common";
 import { map } from "rxjs/operators";
-import { PrismaService } from "src/prisma/prisma.service";
-import { UserLogDto } from "src/user-logs/dto/user-log.dto";
+import { PrismaService } from "../../prisma/prisma.service";
+import { UserLogDto } from "../../user-logs/dto/user-log.dto";
 
 enum LOG_NAMES {
     PROFILE_UPDATED = 'profile_updated',

--- a/src/shared/user-logs/user-log.service.ts
+++ b/src/shared/user-logs/user-log.service.ts
@@ -1,0 +1,252 @@
+import { HttpService, Injectable, Logger } from "@nestjs/common";
+import { map } from "rxjs/operators";
+import { PrismaService } from "src/prisma/prisma.service";
+import { UserLogDto } from "src/user-logs/dto/user-log.dto";
+
+enum LOG_NAMES {
+    PROFILE_UPDATED = 'profile_updated',
+    PROFILE_PASSWORD_CHANGED = 'profile_password_changed',
+    PROJECT_CREATED = 'project_created',
+    PROJECT_DETAILS_UPDATED = 'project_updated',
+    PROJECT_DELETED = 'project_deleted',
+    BUILD_CREATED = 'build_created',
+    BUILD_DELETED = 'build_deleted',
+    USER_CREATED = 'user_created',
+    USER_DELETED = 'user_deleted',
+    TEST_RUNS_DELETED = 'test_runs_deleted',
+    TEST_RUNS_UPDATED = 'test_runs_approved_rejected',
+    TEST_RUNS_APPROVED = 'test_runs_approved',
+    TEST_RUNS_REJECTED = 'test_runs_rejected',
+    UNKNOWN = 'unknown',
+}
+
+type BuildDetails = {
+    buildId: string;
+    buildSerialNumber: number;
+    projectId: string;
+    projectName: string;
+};
+
+@Injectable()
+export class VRTUserLogService {
+
+    private readonly logger: Logger = new Logger(VRTUserLogService.name);
+
+    constructor(private prismaService: PrismaService, private httpService: HttpService) { }
+
+    async getLogs(numberOfRecordsNeeded: number) {
+        return this.httpService.post(`${process.env.ELASTIC_URL}/vrt-user-log/_search`,
+            { "size": numberOfRecordsNeeded, "sort": [{ "@timestamp": "desc" }], "_source": ["vrtEventType", "vrtUser", "vrtMessage"] },
+            {
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+            }).pipe(
+                map(response => response.data),
+            ).toPromise().catch(e => {
+            });
+    }
+
+    async getLastLog() {
+        const lastLogsResponse = await this.getLogs(1);
+        if (lastLogsResponse) {
+            let recentLogs: UserLogDto[] = lastLogsResponse.hits.hits;
+            let recentLogsDto = recentLogs.map(each => new UserLogDto(each))
+            return recentLogsDto[0];
+        }
+    }
+
+    async postData(request: Request, description: string) {
+
+        let user = await this.getUserEmail(request);
+        const eventType = this.getEventyType(request);
+        //description will be undefined if it was not computed as part of pre-delete info collection from DB.
+        if (!description && eventType !== LOG_NAMES.TEST_RUNS_DELETED) {
+            description = await this.getLogDescription(user, eventType, request);
+        }
+        //Case when previous log is similar to current log (example multiple test run approval) or when test run requests do not contain a body.
+        if (description.length === 0) {
+            return;
+        }
+        this.logger.log(eventType.toString() + " ## " + user + " ## " + description);
+    }
+
+    async getLogDescriptionBeforeDeletingFromDB(user: string, request: any) {
+        const eventType = this.getEventyType(request);
+        const description = await this.getLogDescription(user, eventType, request);
+        return description;
+    }
+
+    async getLogDescription(currentUser: string, eventType: LOG_NAMES, request: any) {
+        switch (eventType) {
+            case LOG_NAMES.USER_CREATED: {
+                return `${request.body.email} user created.`;
+            }
+            case LOG_NAMES.USER_DELETED: {
+                let userEmail = await this.prismaService.user.findUnique({
+                    where: {
+                        id: request.body[0],
+                    }
+                });
+                return `${userEmail.email} is deleted.`;
+            }
+            case LOG_NAMES.PROFILE_UPDATED: {
+                return `Profile updated for ${await this.getUserEmail(request)}`;
+            }
+            case LOG_NAMES.PROFILE_PASSWORD_CHANGED: {
+                return `Password changed for ${await this.getUserEmail(request)}`;
+            }
+            case LOG_NAMES.PROJECT_CREATED: {
+                return `Project '${request.body.name}' is created.`;
+            }
+            case LOG_NAMES.PROJECT_DELETED: {
+                const projectId: string = request.url.split('/')[2];
+                let projectFromDB = await this.prismaService.project.findUnique({
+                    where: {
+                        id: projectId,
+                    }
+                });
+                return `Project '${projectFromDB.name}'(${projectId}) is deleted.`;
+            }
+            case LOG_NAMES.PROJECT_DETAILS_UPDATED: {
+                return `'${request.body.name}' project is updated.`;
+            }
+            case LOG_NAMES.BUILD_CREATED: {
+                const projectId = request.body.project;
+                const projectNameFromDB = await this.prismaService.project.findUnique({
+                    where: {
+                        id: projectId,
+                    }
+                });
+                return `Build created for '${projectNameFromDB.name}'(${projectId}) for branch '${request.body.branchName}' with ciBuildId '${request.body.ciBuildId}'.`;
+            }
+            case LOG_NAMES.BUILD_DELETED: {
+                const buildId: string = request.url.split('/')[2];
+                const buildDetails = await this.getBuildAndProjectDetails(buildId);
+                return `Build deleted for project '${buildDetails.projectName}' (${buildDetails.projectId}) and build (${buildDetails.buildId}) with serial number ${buildDetails.buildSerialNumber}.`;
+            }
+            case LOG_NAMES.TEST_RUNS_DELETED:
+            case LOG_NAMES.TEST_RUNS_APPROVED:
+            case LOG_NAMES.TEST_RUNS_REJECTED: {
+                const testRunIds = request.body as Array<string>;
+                if (testRunIds.length === 0) {
+                    return '';
+                }
+                const testRunDetailsFromDB = await this.prismaService.testRun.findFirst({
+                    where: {
+                        id: testRunIds[0],
+                    }
+                });
+
+                const buildId = testRunDetailsFromDB.buildId;
+                const lastLog = await this.getLastLog();
+                if (!currentUser || currentUser.length === 0) {
+                    currentUser = await this.getUserEmail(request);
+                }
+                const isLastLogSimilar = this.isLastLogSimilar(currentUser, lastLog, buildId, eventType);
+                //If last log is similar, consolidate the log. Otherwise, there will be too many logs especially when user navigates in test run details and approved images one by one.
+                if (isLastLogSimilar) {
+                    return '';
+                }
+                const action = (eventType === LOG_NAMES.TEST_RUNS_DELETED) ? 'deleted from' : 'updated in';
+                const buildDetails = await this.getBuildAndProjectDetails(buildId);
+                return `${testRunIds.length} test run(s) ${action} project '${buildDetails.projectName}' (${buildDetails.projectId}) and build (${buildDetails.buildId}) with serial number ${buildDetails.buildSerialNumber}.`;
+            }
+            default: {
+                return '';
+            }
+        }
+    }
+
+    isLastLogSimilar(currentUser: string, lastLog: UserLogDto, buildId: string, eventType: LOG_NAMES): boolean {
+        if (lastLog) {
+            if (!(lastLog.user.includes(currentUser) && lastLog.description.includes(buildId))) {
+                return false;
+            }
+            if (eventType === LOG_NAMES.TEST_RUNS_DELETED && lastLog.eventType === eventType) {
+                return true;
+            }
+            if (lastLog.eventType === LOG_NAMES.TEST_RUNS_APPROVED || lastLog.eventType === LOG_NAMES.TEST_RUNS_REJECTED) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    async getBuildAndProjectDetails(buildId: string): Promise<BuildDetails> {
+        const buildDetailsFromDB = await this.prismaService.build.findUnique({
+            where: {
+                id: buildId,
+            }
+        });
+        const projectDetailsFromDB = await this.prismaService.project.findUnique({
+            where: {
+                id: buildDetailsFromDB.projectId,
+            }
+        });
+        const buildDetails: BuildDetails = {
+            'buildId': buildId,
+            'projectId': buildDetailsFromDB.projectId,
+            'projectName': projectDetailsFromDB.name,
+            'buildSerialNumber': buildDetailsFromDB.number
+        }
+        return buildDetails;
+    }
+
+    async getUserEmail(request: any): Promise<string> {
+        let user = request.user ? request.user.email : request.headers.apikey;
+        if (user && !user.includes('@')) {
+            //We got apikey instead of email, so fetch email from the database.
+            let userFromDB = await this.prismaService.user.findUnique({
+                where: {
+                    apiKey: user,
+                }
+            })
+            user = userFromDB.email;
+        }
+        return user = user ? user : '';
+    }
+
+    private getEventyType(request: any): LOG_NAMES {
+        const method: string = request.method;
+        const url: string = request.url;
+        if (url.startsWith('/users/password')) {
+            return LOG_NAMES.PROFILE_PASSWORD_CHANGED;
+        }
+        if (url.startsWith('/users') && method.includes('DELETE')) {
+            return LOG_NAMES.USER_DELETED;
+        }
+        if (url.startsWith('/users') && method.includes('POST')) {
+            return LOG_NAMES.USER_CREATED;
+        }
+        if (url.startsWith('/users')) {
+            return LOG_NAMES.PROFILE_UPDATED;
+        }
+        if (url.startsWith("/test-runs/delete")) {
+            return LOG_NAMES.TEST_RUNS_DELETED;
+        }
+        if (url.startsWith("/test-runs/approve")) {
+            return LOG_NAMES.TEST_RUNS_APPROVED;
+        }
+        if (url.startsWith("/test-runs/reject")) {
+            return LOG_NAMES.TEST_RUNS_REJECTED;
+        }
+        if (url.startsWith("/builds/") && method.includes('DELETE')) {
+            return LOG_NAMES.BUILD_DELETED;
+        }
+        if (url.startsWith("/builds") && method.includes('POST')) {
+            return LOG_NAMES.BUILD_CREATED;
+        }
+        if (url.startsWith("/projects") && method.includes('POST')) {
+            return LOG_NAMES.PROJECT_CREATED;
+        }
+        if (url.startsWith("/projects") && method.includes('DELETE')) {
+            return LOG_NAMES.PROJECT_DELETED;
+        }
+        if (url.startsWith("/projects") && method.includes('PUT')) {
+            return LOG_NAMES.PROJECT_DETAILS_UPDATED;
+        }
+        return LOG_NAMES.UNKNOWN;
+    }
+
+}

--- a/src/shared/user-logs/user-logs.module.ts
+++ b/src/shared/user-logs/user-logs.module.ts
@@ -1,0 +1,13 @@
+import { HttpModule, Module } from "@nestjs/common";
+import { AuthModule } from "src/auth/auth.module";
+import { UserLogsController } from "src/user-logs/user-logs.controller";
+import { PrismaService } from "src/prisma/prisma.service";
+import { VRTUserLogService } from "./user-log.service";
+
+@Module({
+  imports: [AuthModule, HttpModule],
+  providers: [PrismaService, VRTUserLogService],
+  exports: [VRTUserLogService],
+  controllers: [UserLogsController],
+})
+export class UserLogsModule { }

--- a/src/shared/user-logs/user-logs.module.ts
+++ b/src/shared/user-logs/user-logs.module.ts
@@ -1,7 +1,7 @@
 import { HttpModule, Module } from "@nestjs/common";
-import { AuthModule } from "src/auth/auth.module";
-import { UserLogsController } from "src/user-logs/user-logs.controller";
-import { PrismaService } from "src/prisma/prisma.service";
+import { AuthModule } from "../../auth/auth.module";
+import { UserLogsController } from "../../user-logs/user-logs.controller";
+import { PrismaService } from "../../prisma/prisma.service";
 import { VRTUserLogService } from "./user-log.service";
 
 @Module({

--- a/src/test-runs/test-runs.controller.spec.ts
+++ b/src/test-runs/test-runs.controller.spec.ts
@@ -3,6 +3,7 @@ import { TestRunsController } from './test-runs.controller';
 import { TestRunsService } from './test-runs.service';
 import { TestVariationsService } from '../test-variations/test-variations.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { VRTUserLogService } from '../shared/user-logs/user-log.service';
 
 describe('TestRuns Controller', () => {
   let controller: TestRunsController;
@@ -14,6 +15,7 @@ describe('TestRuns Controller', () => {
         { provide: TestRunsService, useValue: {} },
         { provide: TestVariationsService, useValue: {} },
         { provide: PrismaService, useValue: {} },
+        { provide: VRTUserLogService, useValue: {} },
       ],
     }).compile();
 

--- a/src/test-runs/test-runs.controller.ts
+++ b/src/test-runs/test-runs.controller.ts
@@ -39,7 +39,7 @@ import { UpdateTestRunDto } from './dto/update-test.dto';
 import { CurrentUser } from '../shared/current-user.decorator';
 import { RoleGuard } from '../auth/guards/role.guard';
 import { Roles } from '../shared/roles.decorator';
-import { UserLogInterceptor } from 'src/shared/user-logs/user-log-interceptor';
+import { UserLogInterceptor } from '../shared/user-logs/user-log-interceptor';
 
 @ApiTags('test-runs')
 @Controller('test-runs')

--- a/src/test-runs/test-runs.controller.ts
+++ b/src/test-runs/test-runs.controller.ts
@@ -39,13 +39,14 @@ import { UpdateTestRunDto } from './dto/update-test.dto';
 import { CurrentUser } from '../shared/current-user.decorator';
 import { RoleGuard } from '../auth/guards/role.guard';
 import { Roles } from '../shared/roles.decorator';
+import { UserLogInterceptor } from 'src/shared/user-logs/user-log-interceptor';
 
 @ApiTags('test-runs')
 @Controller('test-runs')
 export class TestRunsController {
   private readonly logger: Logger = new Logger(TestRunsController.name);
 
-  constructor(private testRunsService: TestRunsService) {}
+  constructor(private testRunsService: TestRunsService) { }
 
   @Get()
   @ApiOkResponse({ type: [TestRunDto] })
@@ -60,6 +61,7 @@ export class TestRunsController {
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard, RoleGuard)
   @Roles(Role.admin, Role.editor)
+  @UseInterceptors(UserLogInterceptor)
   async approveTestRun(
     @CurrentUser() user: User,
     @Body() ids: string[],
@@ -75,6 +77,7 @@ export class TestRunsController {
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard, RoleGuard)
   @Roles(Role.admin, Role.editor)
+  @UseInterceptors(UserLogInterceptor)
   async reject(@Body() ids: string[]): Promise<void> {
     this.logger.debug(`Going to reject TestRuns: ${ids}`);
     for (const id of ids) {
@@ -86,6 +89,7 @@ export class TestRunsController {
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard, RoleGuard)
   @Roles(Role.admin, Role.editor)
+  @UseInterceptors(UserLogInterceptor)
   async delete(@Body() ids: string[]): Promise<void> {
     this.logger.debug(`Going to delete TestRuns: ${ids}`);
     for (const id of ids) {

--- a/src/test-runs/test-runs.module.ts
+++ b/src/test-runs/test-runs.module.ts
@@ -5,7 +5,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { TestRunsController } from './test-runs.controller';
 import { TestVariationsModule } from '../test-variations/test-variations.module';
 import { CompareModule } from '../compare/compare.module';
-import { VRTUserLogService } from 'src/shared/user-logs/user-log.service';
+import { VRTUserLogService } from '../shared/user-logs/user-log.service';
 
 @Module({
   imports: [SharedModule, forwardRef(() => TestVariationsModule), CompareModule, HttpModule],

--- a/src/test-runs/test-runs.module.ts
+++ b/src/test-runs/test-runs.module.ts
@@ -1,15 +1,16 @@
-import { forwardRef, Module } from '@nestjs/common';
+import { forwardRef, HttpModule, Module } from '@nestjs/common';
 import { TestRunsService } from './test-runs.service';
 import { SharedModule } from '../shared/shared.module';
 import { PrismaService } from '../prisma/prisma.service';
 import { TestRunsController } from './test-runs.controller';
 import { TestVariationsModule } from '../test-variations/test-variations.module';
 import { CompareModule } from '../compare/compare.module';
+import { VRTUserLogService } from 'src/shared/user-logs/user-log.service';
 
 @Module({
-  imports: [SharedModule, forwardRef(() => TestVariationsModule), CompareModule],
-  providers: [TestRunsService, PrismaService],
+  imports: [SharedModule, forwardRef(() => TestVariationsModule), CompareModule, HttpModule],
+  providers: [TestRunsService, PrismaService, VRTUserLogService],
   controllers: [TestRunsController],
   exports: [TestRunsService],
 })
-export class TestRunsModule {}
+export class TestRunsModule { }

--- a/src/user-logs/dto/user-log.dto.ts
+++ b/src/user-logs/dto/user-log.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserLogDto {
+
+    @ApiProperty()
+    readonly id: string;
+
+    @ApiProperty()
+    readonly user: string;
+
+    @ApiProperty()
+    readonly timestamp: Date;
+
+    @ApiProperty()
+    readonly eventType: string;
+
+    @ApiProperty()
+    readonly description: string;
+
+    constructor(elasticObject: any) {
+        this.id = elasticObject._id;
+        this.eventType = elasticObject._source.vrtEventType;
+        this.user = elasticObject._source.vrtUser;
+        this.description = elasticObject._source.vrtMessage;
+        this.timestamp = new Date(elasticObject.sort[0]);
+    }
+
+}

--- a/src/user-logs/user-logs.controller.ts
+++ b/src/user-logs/user-logs.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiOkResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/auth.guard';
+import { Logger } from '@nestjs/common';
+import { UserLogDto } from './dto/user-log.dto';
+import { VRTUserLogService } from 'src/shared/user-logs/user-log.service';
+
+@Controller('logs')
+export class UserLogsController {
+    private readonly logger: Logger = new Logger(UserLogsController.name);
+
+    constructor(private logService: VRTUserLogService) { }
+
+    @Get()
+    @ApiOkResponse({ type: [UserLogDto] })
+    @ApiBearerAuth()
+    @UseGuards(JwtAuthGuard)
+    async logList() : Promise<UserLogDto[]> {
+        let allLogsResponse = await this.logService.getLogs(100);
+        if (allLogsResponse) {
+            let allLogs: UserLogDto[] = allLogsResponse.hits.hits;
+            //Sometimes elastic returns empty object, filter that out.
+            let allLogsDto = allLogs.map(each => new UserLogDto(each)).filter(e => e.eventType);
+            return allLogsDto;
+        } else {
+            //Case when elastic server is not configured.
+            let elasticObject = { "_id": "id", "_source": { "vrtEventType": "", "vrtUser": "", "vrtMessage": "No logs found. Elastic server is required. Setup documentation in Github VRT page." }, "sort": [new Date().getTime()] };
+            const emptyLogToReturn: UserLogDto = new UserLogDto(elasticObject);
+            return [emptyLogToReturn];
+        }
+    }
+
+}

--- a/src/user-logs/user-logs.controller.ts
+++ b/src/user-logs/user-logs.controller.ts
@@ -3,7 +3,7 @@ import { ApiOkResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/auth.guard';
 import { Logger } from '@nestjs/common';
 import { UserLogDto } from './dto/user-log.dto';
-import { VRTUserLogService } from 'src/shared/user-logs/user-log.service';
+import { VRTUserLogService } from '../shared/user-logs/user-log.service';
 
 @Controller('logs')
 export class UserLogsController {

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { VRTUserLogService } from '../shared/user-logs/user-log.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
@@ -12,6 +13,7 @@ describe('Users Controller', () => {
       providers: [
         { provide: UsersService, useValue: {} },
         { provide: PrismaService, useValue: {} },
+        { provide: VRTUserLogService, useValue: {} },
       ],
     }).compile();
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Get, UseGuards, Put, Delete, Param, ParseUUIDPipe, Patch } from '@nestjs/common';
+import { Controller, Post, Body, Get, UseGuards, Put, Delete, Param, ParseUUIDPipe, Patch, UseInterceptors } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { ApiOkResponse, ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { UserLoginResponseDto } from './dto/user-login-response.dto';
@@ -14,6 +14,7 @@ import { Roles } from '../shared/roles.decorator';
 import { PrismaService } from '../prisma/prisma.service';
 import { AssignRoleDto } from './dto/assign-role.dto';
 import { Logger } from '@nestjs/common';
+import { UserLogInterceptor } from 'src/shared/user-logs/user-log-interceptor';
 
 @Controller('users')
 @ApiTags('users')
@@ -24,6 +25,7 @@ export class UsersController {
 
   @Post('register')
   @ApiOkResponse({ type: UserLoginResponseDto })
+  @UseInterceptors(UserLogInterceptor)
   register(@Body() createUserDto: CreateUserDto): Promise<UserLoginResponseDto> {
     return this.usersService.create(createUserDto);
   }
@@ -46,6 +48,7 @@ export class UsersController {
   @ApiOkResponse({ type: Boolean })
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
+  @UseInterceptors(UserLogInterceptor)
   changePassword(@CurrentUser() user: User, @Body('password') password: string): Promise<boolean> {
     return this.usersService.changePassword(user, password);
   }
@@ -54,6 +57,7 @@ export class UsersController {
   @ApiOkResponse({ type: UserLoginResponseDto })
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
+  @UseInterceptors(UserLogInterceptor)
   update(@CurrentUser() user: User, @Body() updateUserDto: UpdateUserDto): Promise<UserLoginResponseDto> {
     return this.usersService.update(user.id, updateUserDto);
   }
@@ -73,6 +77,7 @@ export class UsersController {
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard, RoleGuard)
   @Roles(Role.admin)
+  @UseInterceptors(UserLogInterceptor)
   async delete(@Body() ids: string[]): Promise<void> {
     this.logger.debug(`Going to remove User: ${ids}`);
     for (const id of ids) {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -14,7 +14,7 @@ import { Roles } from '../shared/roles.decorator';
 import { PrismaService } from '../prisma/prisma.service';
 import { AssignRoleDto } from './dto/assign-role.dto';
 import { Logger } from '@nestjs/common';
-import { UserLogInterceptor } from 'src/shared/user-logs/user-log-interceptor';
+import { UserLogInterceptor } from '../shared/user-logs/user-log-interceptor';
 
 @Controller('users')
 @ApiTags('users')

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -3,7 +3,7 @@ import { UsersService } from './users.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { UsersController } from './users.controller';
 import { AuthModule } from '../auth/auth.module';
-import { VRTUserLogService } from 'src/shared/user-logs/user-log.service';
+import { VRTUserLogService } from '../shared/user-logs/user-log.service';
 
 @Module({
   imports: [AuthModule, HttpModule],

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,13 +1,14 @@
-import { Module } from '@nestjs/common';
+import { HttpModule, Module } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { UsersController } from './users.controller';
 import { AuthModule } from '../auth/auth.module';
+import { VRTUserLogService } from 'src/shared/user-logs/user-log.service';
 
 @Module({
-  imports: [AuthModule],
-  providers: [UsersService, PrismaService],
+  imports: [AuthModule, HttpModule],
+  providers: [UsersService, PrismaService, VRTUserLogService],
   exports: [UsersService],
   controllers: [UsersController],
 })
-export class UsersModule {}
+export class UsersModule { }


### PR DESCRIPTION
Possible to fetch user action-related log from elastic. Uses interceptor to log actions and exposes an endpoint to get latest logs from elastic search. This can be consumed in the VRT UI to show important events - issue:  https://github.com/Visual-Regression-Tracker/Visual-Regression-Tracker/issues/206
In case elastic is not configured, it will return with a statement that elastic is not configured. VRT UI will just say that it cannot display log because elastic is not configured.

<img width="1133" alt="image001" src="https://user-images.githubusercontent.com/9042580/136470521-9881bb88-9966-47bb-8a3e-fd9a2e11e27f.png">
<img width="1071" alt="image002" src="https://user-images.githubusercontent.com/9042580/136470516-36e76bd0-8df0-4495-a786-f2cd13bb918b.png">
