### PR TITLE
If branch not sent, take default branch

### DIFF
--- a/src/builds/builds.controller.ts
+++ b/src/builds/builds.controller.ts
@@ -75,7 +75,7 @@ export class BuildsController {
     await this.buildsService.deleteOldBuilds(project.id, project.maxBuildAllowed);
     const build = await this.buildsService.findOrCreate({
       projectId: project.id,
-      branchName: createBuildDto.branchName,
+      branchName: (createBuildDto.branchName && createBuildDto.branchName.trim().length > 0) ? createBuildDto.branchName : project.mainBranchName,
       ciBuildId: createBuildDto.ciBuildId,
     });
     return new BuildDto(build);

--- a/src/builds/builds.controller.ts
+++ b/src/builds/builds.controller.ts
@@ -75,7 +75,7 @@ export class BuildsController {
     await this.buildsService.deleteOldBuilds(project.id, project.maxBuildAllowed);
     const build = await this.buildsService.findOrCreate({
       projectId: project.id,
-      branchName: (createBuildDto.branchName && createBuildDto.branchName.trim().length > 0) ? createBuildDto.branchName : project.mainBranchName,
+      branchName: createBuildDto.branchName ?? project.mainBranchName,
       ciBuildId: createBuildDto.ciBuildId,
     });
     return new BuildDto(build);

--- a/src/builds/dto/build-create.dto.ts
+++ b/src/builds/dto/build-create.dto.ts
@@ -8,9 +8,11 @@ export class CreateBuildDto {
   @IsNotEmpty()
   readonly ciBuildId?: string;
 
-  @ApiProperty()
+  @ApiPropertyOptional()
+  @IsOptional()
   @IsString()
-  readonly branchName: string;
+  @IsNotEmpty()
+  readonly branchName?: string;
 
   @ApiProperty()
   @IsString()

--- a/test/builds.e2e-spec.ts
+++ b/test/builds.e2e-spec.ts
@@ -94,6 +94,23 @@ describe('Builds (e2e)', () => {
         });
     });
 
+    it('201 with no branchname and no ciBuildId', () => {
+      const createBuildDto: CreateBuildDto = {
+        project: project.id,
+      };
+      return requestWithApiKey(app, 'post', '/builds', user.apiKey)
+        .send(createBuildDto)
+        .expect(201)
+        .expect((res) => {
+          expect(res.body.projectId).toBe(project.id);
+          expect(res.body.branchName).toBe(TEST_PROJECT.mainBranchName);
+          expect(res.body.failedCount).toBe(0);
+          expect(res.body.passedCount).toBe(0);
+          expect(res.body.unresolvedCount).toBe(0);
+          expect(res.body.isRunning).toBe(true);
+        });
+    });
+
     it('201 by name', () => {
       const createBuildDto: CreateBuildDto = {
         branchName: 'branchName',

--- a/test/builds.e2e-spec.ts
+++ b/test/builds.e2e-spec.ts
@@ -76,6 +76,24 @@ describe('Builds (e2e)', () => {
         });
     });
 
+    it('201 by null branchname', () => {
+      const createBuildDto: CreateBuildDto = {
+        branchName: null,
+        project: project.id,
+      };
+      return requestWithApiKey(app, 'post', '/builds', user.apiKey)
+        .send(createBuildDto)
+        .expect(201)
+        .expect((res) => {
+          expect(res.body.projectId).toBe(project.id);
+          expect(res.body.branchName).toBe(TEST_PROJECT.mainBranchName);
+          expect(res.body.failedCount).toBe(0);
+          expect(res.body.passedCount).toBe(0);
+          expect(res.body.unresolvedCount).toBe(0);
+          expect(res.body.isRunning).toBe(true);
+        });
+    });
+
     it('201 by name', () => {
       const createBuildDto: CreateBuildDto = {
         branchName: 'branchName',


### PR DESCRIPTION
This will enable SDK and clients not to send branch information. That way, it will use the default branch if not provided.