### PR TITLE
feat(312): add optional comment property for test runs

### DIFF
--- a/src/test-runs/dto/create-test-request.dto.ts
+++ b/src/test-runs/dto/create-test-request.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsOptional, IsUUID, IsNumber, IsBoolean } from 'class-validator';
+import { IsOptional, IsUUID, IsNumber, IsBoolean, IsString } from 'class-validator';
 import { isArray } from 'lodash';
 import { BaselineDataDto } from '../../shared/dto/baseline-data.dto';
 import { IgnoreAreaDto } from './ignore-area.dto';
@@ -17,13 +17,13 @@ export class CreateTestRequestDto extends BaselineDataDto {
   @ApiPropertyOptional()
   @IsOptional()
   @IsNumber()
-  @Transform(({value}) => parseFloat(value))
+  @Transform(({ value }) => parseFloat(value))
   diffTollerancePercent?: number;
 
   @ApiPropertyOptional()
   @IsBoolean()
   @IsOptional()
-  @Transform(({value}) => {
+  @Transform(({ value }) => {
     switch (value) {
       case 'true':
         return true;
@@ -37,11 +37,16 @@ export class CreateTestRequestDto extends BaselineDataDto {
 
   @ApiPropertyOptional({ type: [IgnoreAreaDto] })
   @IsOptional()
-  @Transform(({value}) => {
+  @Transform(({ value }) => {
     if (isArray(value)) {
       return it;
     }
     return JSON.parse(value);
   })
   ignoreAreas?: IgnoreAreaDto[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  comment?: string;
 }

--- a/src/test-runs/test-runs.service.spec.ts
+++ b/src/test-runs/test-runs.service.spec.ts
@@ -504,6 +504,7 @@ describe('TestRunsService', () => {
       device: 'device',
       branchName: 'develop',
       customTags: 'customTags',
+      comment: 'new comment',
     };
     const testVariation: TestVariation = {
       id: '123',

--- a/src/test-runs/test-runs.service.ts
+++ b/src/test-runs/test-runs.service.ts
@@ -34,9 +34,7 @@ export class TestRunsService {
     return list.map((item) => new TestRunDto(item));
   }
 
-  async findOne(
-    id: string
-  ): Promise<
+  async findOne(id: string): Promise<
     TestRun & {
       testVariation?: TestVariation;
     }
@@ -233,7 +231,7 @@ export class TestRunsService {
         baselineBranchName: testVariation.branchName,
         ignoreAreas: testVariation.ignoreAreas,
         tempIgnoreAreas: JSON.stringify(createTestRequestDto.ignoreAreas),
-        comment: testVariation.comment,
+        comment: createTestRequestDto.comment || testVariation.comment,
         diffTollerancePercent: createTestRequestDto.diffTollerancePercent,
         branchName: createTestRequestDto.branchName,
         merge: createTestRequestDto.merge,

--- a/test/test-runs.e2e-spec.ts
+++ b/test/test-runs.e2e-spec.ts
@@ -218,6 +218,7 @@ describe('TestRuns (e2e)', () => {
         .field('diffTollerancePercent', '0.12')
         .field('merge', 'false')
         .field('ignoreAreas', '[]')
+        .field('comment', 'Comment')
         .attach('image', image_v1)
         .expect(201);
     });


### PR DESCRIPTION
To support adding comments through SDK, we have to update the test run service to accept optional comment first. 

Details of the request  can be found here: [#312](https://github.com/Visual-Regression-Tracker/Visual-Regression-Tracker/issues/312)

Tested with postman locally and updated tests, all passing.
<img width="1393" alt="Screen Shot 2022-05-07 at 1 46 48 PM" src="https://user-images.githubusercontent.com/12203794/167268121-6a58ee96-997e-4974-946a-ec5bc6b0897b.png">
<img width="1330" alt="Screen Shot 2022-05-07 at 1 48 51 PM" src="https://user-images.githubusercontent.com/12203794/167268123-569c135f-dead-480f-924b-a01048b78357.png">
