### PR TITLE
let cleanOldTestVariations respect project boundaries

### DIFF
--- a/src/shared/tasks/tasks.service.ts
+++ b/src/shared/tasks/tasks.service.ts
@@ -23,6 +23,7 @@ export class TasksService {
 
       const testVariations = await this.prismaService.testVariation.findMany({
         where: {
+          projectId: project.id,
           updatedAt: { lte: dateRemoveAfter },
           branchName: { not: project.mainBranchName },
         },


### PR DESCRIPTION
this fixes Visual-Regression-Tracker/Visual-Regression-Tracker#382