### PR TITLE
Use mocked from jest-mock instead of ts-jest, since it was moved

### DIFF
--- a/src/builds/builds.service.spec.ts
+++ b/src/builds/builds.service.spec.ts
@@ -4,7 +4,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { TestRunsService } from '../test-runs/test-runs.service';
 import { EventsGateway } from '../shared/events/events.gateway';
 import { Build, TestRun, TestStatus } from '@prisma/client';
-import { mocked } from 'ts-jest/utils';
+import { mocked } from 'jest-mock';
 import { BuildDto } from './dto/build.dto';
 import { ProjectsService } from '../projects/projects.service';
 import { generateTestRun } from '../_data_';

--- a/src/compare/libs/pixelmatch/pixelmatch.service.spec.ts
+++ b/src/compare/libs/pixelmatch/pixelmatch.service.spec.ts
@@ -2,7 +2,7 @@ import { TestingModule, Test } from '@nestjs/testing';
 import { TestStatus } from '@prisma/client';
 import Pixelmatch from 'pixelmatch';
 import { PNG } from 'pngjs';
-import { mocked } from 'ts-jest/utils';
+import { mocked } from 'jest-mock';
 import { StaticService } from '../../../shared/static/static.service';
 import { DIFF_DIMENSION_RESULT, EQUAL_RESULT, NO_BASELINE_RESULT } from '../consts';
 import { DEFAULT_CONFIG, PixelmatchService } from './pixelmatch.service';

--- a/src/test-runs/test-runs.service.spec.ts
+++ b/src/test-runs/test-runs.service.spec.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils';
+import { mocked } from 'jest-mock';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TestRunsService } from './test-runs.service';
 import { PrismaService } from '../prisma/prisma.service';


### PR DESCRIPTION
After seeing a deprecation warning, followed to https://github.com/jestjs/jest/pull/12089, changed the place where `mocked` method comes from.

... but should `jest-mock` be added specifically to `devDependencies`?