### PR TITLE
Update Prisma to v5.1.1 and define Node.js 18 LTS as the minimum

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Local setup
 
-- Install Node `14`
+- Install Node `18` (LTS)
 - clone repo
 - Update `.env` and `prisma/.env`
 - Make sure Postgres is up and running, using `docker-compose up` in a separate terminal

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@nestjs/swagger": "^5.2.0",
         "@nestjs/terminus": "^8.0.8",
         "@nestjs/websockets": "^8.4.1",
-        "@prisma/client": "^5.0.0",
+        "@prisma/client": "^5.1.1",
         "ajv": "^8.10.0",
         "bcryptjs": "^2.4.3",
         "cache-manager": "^3.6.0",
@@ -67,7 +67,7 @@
         "eslint-plugin-import": "^2.25.4",
         "jest": "^27.5.1",
         "prettier": "^2.6.0",
-        "prisma": "^5.0.0",
+        "prisma": "^5.1.1",
         "supertest": "^6.2.2",
         "ts-jest": "^27.1.3",
         "ts-loader": "^9.2.8",
@@ -2292,12 +2292,12 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.0.0.tgz",
-      "integrity": "sha512-XlO5ELNAQ7rV4cXIDJUNBEgdLwX3pjtt9Q/RHqDpGf43szpNJx2hJnggfFs7TKNx0cOFsl6KJCSfqr5duEU/bQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.1.1.tgz",
+      "integrity": "sha512-fxcCeK5pMQGcgCqCrWsi+I2rpIbk0rAhdrN+ke7f34tIrgPwA68ensrpin+9+fZvuV2OtzHmuipwduSY6HswdA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584"
+        "@prisma/engines-version": "5.1.1-1.6a3747c37ff169c90047725a05a6ef02e32ac97e"
       },
       "engines": {
         "node": ">=16.13"
@@ -2312,16 +2312,16 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.0.0.tgz",
-      "integrity": "sha512-kyT/8fd0OpWmhAU5YnY7eP31brW1q1YrTGoblWrhQJDiN/1K+Z8S1kylcmtjqx5wsUGcP1HBWutayA/jtyt+sg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.1.1.tgz",
+      "integrity": "sha512-NV/4nVNWFZSJCCIA3HIFJbbDKO/NARc9ej0tX5S9k2EVbkrFJC4Xt9b0u4rNZWL4V+F5LAjvta8vzEUw0rw+HA==",
       "devOptional": true,
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584.tgz",
-      "integrity": "sha512-HHiUF6NixsldsP3JROq07TYBLEjXFKr6PdH8H4gK/XAoTmIplOJBCgrIUMrsRAnEuGyRoRLXKXWUb943+PFoKQ=="
+      "version": "5.1.1-1.6a3747c37ff169c90047725a05a6ef02e32ac97e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.1.1-1.6a3747c37ff169c90047725a05a6ef02e32ac97e.tgz",
+      "integrity": "sha512-owZqbY/wucbr65bXJ/ljrHPgQU5xXTSkmcE/JcbqE1kusuAXV/TLN3/exmz21SZ5rJ7WDkyk70J2G/n68iogbQ=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -9511,13 +9511,13 @@
       }
     },
     "node_modules/prisma": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.0.0.tgz",
-      "integrity": "sha512-KYWk83Fhi1FH59jSpavAYTt2eoMVW9YKgu8ci0kuUnt6Dup5Qy47pcB4/TLmiPAbhGrxxSz7gsSnJcCmkyPANA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.1.1.tgz",
+      "integrity": "sha512-WJFG/U7sMmcc6TjJTTifTfpI6Wjoh55xl4AzopVwAdyK68L9/ogNo8QQ2cxuUjJf/Wa82z/uhyh3wMzvRIBphg==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "5.0.0"
+        "@prisma/engines": "5.1.1"
       },
       "bin": {
         "prisma": "build/index.js"
@@ -13367,23 +13367,23 @@
       }
     },
     "@prisma/client": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.0.0.tgz",
-      "integrity": "sha512-XlO5ELNAQ7rV4cXIDJUNBEgdLwX3pjtt9Q/RHqDpGf43szpNJx2hJnggfFs7TKNx0cOFsl6KJCSfqr5duEU/bQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.1.1.tgz",
+      "integrity": "sha512-fxcCeK5pMQGcgCqCrWsi+I2rpIbk0rAhdrN+ke7f34tIrgPwA68ensrpin+9+fZvuV2OtzHmuipwduSY6HswdA==",
       "requires": {
-        "@prisma/engines-version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584"
+        "@prisma/engines-version": "5.1.1-1.6a3747c37ff169c90047725a05a6ef02e32ac97e"
       }
     },
     "@prisma/engines": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.0.0.tgz",
-      "integrity": "sha512-kyT/8fd0OpWmhAU5YnY7eP31brW1q1YrTGoblWrhQJDiN/1K+Z8S1kylcmtjqx5wsUGcP1HBWutayA/jtyt+sg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.1.1.tgz",
+      "integrity": "sha512-NV/4nVNWFZSJCCIA3HIFJbbDKO/NARc9ej0tX5S9k2EVbkrFJC4Xt9b0u4rNZWL4V+F5LAjvta8vzEUw0rw+HA==",
       "devOptional": true
     },
     "@prisma/engines-version": {
-      "version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584.tgz",
-      "integrity": "sha512-HHiUF6NixsldsP3JROq07TYBLEjXFKr6PdH8H4gK/XAoTmIplOJBCgrIUMrsRAnEuGyRoRLXKXWUb943+PFoKQ=="
+      "version": "5.1.1-1.6a3747c37ff169c90047725a05a6ef02e32ac97e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.1.1-1.6a3747c37ff169c90047725a05a6ef02e32ac97e.tgz",
+      "integrity": "sha512-owZqbY/wucbr65bXJ/ljrHPgQU5xXTSkmcE/JcbqE1kusuAXV/TLN3/exmz21SZ5rJ7WDkyk70J2G/n68iogbQ=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -18942,12 +18942,12 @@
       }
     },
     "prisma": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.0.0.tgz",
-      "integrity": "sha512-KYWk83Fhi1FH59jSpavAYTt2eoMVW9YKgu8ci0kuUnt6Dup5Qy47pcB4/TLmiPAbhGrxxSz7gsSnJcCmkyPANA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.1.1.tgz",
+      "integrity": "sha512-WJFG/U7sMmcc6TjJTTifTfpI6Wjoh55xl4AzopVwAdyK68L9/ogNo8QQ2cxuUjJf/Wa82z/uhyh3wMzvRIBphg==",
       "devOptional": true,
       "requires": {
-        "@prisma/engines": "5.0.0"
+        "@prisma/engines": "5.1.1"
       }
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:acceptance": "jest --projects test_acceptance"
   },
   "engines": {
-    "node": ">=16.13.0"
+    "node": ">=18.12.0"
   },
   "dependencies": {
     "@nestjs/common": "^8.4.1",
@@ -36,7 +36,7 @@
     "@nestjs/swagger": "^5.2.0",
     "@nestjs/terminus": "^8.0.8",
     "@nestjs/websockets": "^8.4.1",
-    "@prisma/client": "^5.0.0",
+    "@prisma/client": "^5.1.1",
     "ajv": "^8.10.0",
     "bcryptjs": "^2.4.3",
     "cache-manager": "^3.6.0",
@@ -83,7 +83,7 @@
     "eslint-plugin-import": "^2.25.4",
     "jest": "^27.5.1",
     "prettier": "^2.6.0",
-    "prisma": "^5.0.0",
+    "prisma": "^5.1.1",
     "supertest": "^6.2.2",
     "ts-jest": "^27.1.3",
     "ts-loader": "^9.2.8",

--- a/prisma/package-lock.json
+++ b/prisma/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/client": "^5.0.0",
+        "@prisma/client": "^5.1.1",
         "bcryptjs": "^2.4.3"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.2",
-        "prisma": "^5.0.0",
+        "prisma": "^5.1.1",
         "ts-node": "^10.7.0",
         "typescript": "^4.9.2"
       }
@@ -57,12 +57,12 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.0.0.tgz",
-      "integrity": "sha512-XlO5ELNAQ7rV4cXIDJUNBEgdLwX3pjtt9Q/RHqDpGf43szpNJx2hJnggfFs7TKNx0cOFsl6KJCSfqr5duEU/bQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.1.1.tgz",
+      "integrity": "sha512-fxcCeK5pMQGcgCqCrWsi+I2rpIbk0rAhdrN+ke7f34tIrgPwA68ensrpin+9+fZvuV2OtzHmuipwduSY6HswdA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584"
+        "@prisma/engines-version": "5.1.1-1.6a3747c37ff169c90047725a05a6ef02e32ac97e"
       },
       "engines": {
         "node": ">=16.13"
@@ -77,16 +77,16 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.0.0.tgz",
-      "integrity": "sha512-kyT/8fd0OpWmhAU5YnY7eP31brW1q1YrTGoblWrhQJDiN/1K+Z8S1kylcmtjqx5wsUGcP1HBWutayA/jtyt+sg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.1.1.tgz",
+      "integrity": "sha512-NV/4nVNWFZSJCCIA3HIFJbbDKO/NARc9ej0tX5S9k2EVbkrFJC4Xt9b0u4rNZWL4V+F5LAjvta8vzEUw0rw+HA==",
       "devOptional": true,
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584.tgz",
-      "integrity": "sha512-HHiUF6NixsldsP3JROq07TYBLEjXFKr6PdH8H4gK/XAoTmIplOJBCgrIUMrsRAnEuGyRoRLXKXWUb943+PFoKQ=="
+      "version": "5.1.1-1.6a3747c37ff169c90047725a05a6ef02e32ac97e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.1.1-1.6a3747c37ff169c90047725a05a6ef02e32ac97e.tgz",
+      "integrity": "sha512-owZqbY/wucbr65bXJ/ljrHPgQU5xXTSkmcE/JcbqE1kusuAXV/TLN3/exmz21SZ5rJ7WDkyk70J2G/n68iogbQ=="
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -179,13 +179,13 @@
       "dev": true
     },
     "node_modules/prisma": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.0.0.tgz",
-      "integrity": "sha512-KYWk83Fhi1FH59jSpavAYTt2eoMVW9YKgu8ci0kuUnt6Dup5Qy47pcB4/TLmiPAbhGrxxSz7gsSnJcCmkyPANA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.1.1.tgz",
+      "integrity": "sha512-WJFG/U7sMmcc6TjJTTifTfpI6Wjoh55xl4AzopVwAdyK68L9/ogNo8QQ2cxuUjJf/Wa82z/uhyh3wMzvRIBphg==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "5.0.0"
+        "@prisma/engines": "5.1.1"
       },
       "bin": {
         "prisma": "build/index.js"
@@ -299,23 +299,23 @@
       }
     },
     "@prisma/client": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.0.0.tgz",
-      "integrity": "sha512-XlO5ELNAQ7rV4cXIDJUNBEgdLwX3pjtt9Q/RHqDpGf43szpNJx2hJnggfFs7TKNx0cOFsl6KJCSfqr5duEU/bQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.1.1.tgz",
+      "integrity": "sha512-fxcCeK5pMQGcgCqCrWsi+I2rpIbk0rAhdrN+ke7f34tIrgPwA68ensrpin+9+fZvuV2OtzHmuipwduSY6HswdA==",
       "requires": {
-        "@prisma/engines-version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584"
+        "@prisma/engines-version": "5.1.1-1.6a3747c37ff169c90047725a05a6ef02e32ac97e"
       }
     },
     "@prisma/engines": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.0.0.tgz",
-      "integrity": "sha512-kyT/8fd0OpWmhAU5YnY7eP31brW1q1YrTGoblWrhQJDiN/1K+Z8S1kylcmtjqx5wsUGcP1HBWutayA/jtyt+sg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.1.1.tgz",
+      "integrity": "sha512-NV/4nVNWFZSJCCIA3HIFJbbDKO/NARc9ej0tX5S9k2EVbkrFJC4Xt9b0u4rNZWL4V+F5LAjvta8vzEUw0rw+HA==",
       "devOptional": true
     },
     "@prisma/engines-version": {
-      "version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584.tgz",
-      "integrity": "sha512-HHiUF6NixsldsP3JROq07TYBLEjXFKr6PdH8H4gK/XAoTmIplOJBCgrIUMrsRAnEuGyRoRLXKXWUb943+PFoKQ=="
+      "version": "5.1.1-1.6a3747c37ff169c90047725a05a6ef02e32ac97e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.1.1-1.6a3747c37ff169c90047725a05a6ef02e32ac97e.tgz",
+      "integrity": "sha512-owZqbY/wucbr65bXJ/ljrHPgQU5xXTSkmcE/JcbqE1kusuAXV/TLN3/exmz21SZ5rJ7WDkyk70J2G/n68iogbQ=="
     },
     "@tsconfig/node10": {
       "version": "1.0.9",
@@ -396,12 +396,12 @@
       "dev": true
     },
     "prisma": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.0.0.tgz",
-      "integrity": "sha512-KYWk83Fhi1FH59jSpavAYTt2eoMVW9YKgu8ci0kuUnt6Dup5Qy47pcB4/TLmiPAbhGrxxSz7gsSnJcCmkyPANA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.1.1.tgz",
+      "integrity": "sha512-WJFG/U7sMmcc6TjJTTifTfpI6Wjoh55xl4AzopVwAdyK68L9/ogNo8QQ2cxuUjJf/Wa82z/uhyh3wMzvRIBphg==",
       "devOptional": true,
       "requires": {
-        "@prisma/engines": "5.0.0"
+        "@prisma/engines": "5.1.1"
       }
     },
     "ts-node": {

--- a/prisma/package.json
+++ b/prisma/package.json
@@ -7,12 +7,12 @@
   "license": "Apache-2.0",
   "scripts": {},
   "dependencies": {
-    "@prisma/client": "^5.0.0",
+    "@prisma/client": "^5.1.1",
     "bcryptjs": "^2.4.3"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.2",
-    "prisma": "^5.0.0",
+    "prisma": "^5.1.1",
     "ts-node": "^10.7.0",
     "typescript": "^4.9.2"
   }


### PR DESCRIPTION
Once every often I have come across the issue where the Prisma client dependency has not been found, even after it was specifically generated.

Looking at
* https://github.com/prisma/prisma/issues/7234
* https://github.com/prisma/prisma/issues/17162
* https://www.prisma.io/docs/concepts/components/prisma-client/working-with-prismaclient/generating-prisma-client
...got the idea to define where the generated client should go.

## Before `npx prisma generate`:

Environment variables loaded from .env
Environment variables loaded from prisma/.env
Prisma schema loaded from prisma/schema.prisma

✔ Generated Prisma Client (5.1.1 | library) to ./prisma/node_modules/@prisma/client in 218ms
You can now start using Prisma Client in your code. Reference: https://pris.ly/d/client
```
import { PrismaClient } from '@prisma/client'
const prisma = new PrismaClient()
```

## After `npx prisma generate`:

Environment variables loaded from .env
Environment variables loaded from prisma/.env
Prisma schema loaded from prisma/schema.prisma

✔ Generated Prisma Client (5.1.1 | library) to ./node_modules/.prisma/client in 223ms
You can now start using Prisma Client in your code. Reference: https://pris.ly/d/client
```
import { PrismaClient } from './node_modules/.prisma/client'
const prisma = new PrismaClient()
```

## But then reverted

Since there were issues with Docker builds and since "it works most of the time", I gave it a rest.