### PR TITLE
🩹 Use debian base image to allow using odiff as diffing backend (#297)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm run test:cov
 
       - name: Build and run containers
-        run: docker-compose up --build -d
+        run: docker compose up --build -d
 
       - name: Run acceptance tests
         run: npm run test:acceptance
@@ -38,7 +38,7 @@ jobs:
 
       - name: Stop containers
         if: always()
-        run: docker-compose down
+        run: docker compose down
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-# https://github.com/Visual-Regression-Tracker/Visual-Regression-Tracker/issues/137
-FROM node:18-alpine3.18 AS builder
-
+FROM node:18-bookworm-slim AS builder
 # Create app directory
 WORKDIR /app
 
@@ -17,8 +15,9 @@ COPY src ./src
 
 RUN npm run build
 
-# https://github.com/Visual-Regression-Tracker/Visual-Regression-Tracker/issues/137
-FROM node:18-alpine3.18
+FROM node:18-bookworm-slim
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt install -y libssl3 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package*.json ./
 COPY --from=builder /app/dist ./dist

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - Install Node `18` (LTS)
 - clone repo
 - Update `.env` and `prisma/.env`
-- Make sure Postgres is up and running, using `docker-compose up` in a separate terminal
+- Make sure Postgres is up and running, using `docker compose up` in a separate terminal
 - `npm i`
 - `npm run test`
 - Create DB structure `npx prisma db push`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   api:
     container_name: vrt_api

--- a/prisma/Dockerfile
+++ b/prisma/Dockerfile
@@ -1,7 +1,6 @@
-# https://github.com/Visual-Regression-Tracker/Visual-Regression-Tracker/issues/137
-FROM node:18-alpine3.18
-
-RUN apk add --no-cache bash
+FROM node:18-bookworm-slim
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt install -y libssl3 && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
* 👌 Use debian base image to allow usage of odiff

Odiff isn't ABI compatible with musl-libc (alpine) and thus causes crashes when called. Where as debian uses gnu-libc which is compatible with the odiff binaries.

* 🧹 Remove deprecated docker compose file version

Ref.: https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-and-name-top-level-elements

* 🤔 Also use debian base image for migrations? (consistency)

Using the same base image for migration and the API might reduce debugging afford for bugs related to prisma alpine/debian differences (i.e. binaryTargets)

* 🩹🚇 Use docker compose v2 CLI call in workflow

This fixes the error: "docker-compose: command not found"