### PR TITLE
fix PrismaClientInitializationError

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY ./prisma/schema.prisma ./
 COPY package*.json ./
 
 # Install app dependencies
+ENV NODE_TLS_REJECT_UNAUTHORIZED='0'
 RUN npm ci --verbose
 
 COPY tsconfig*.json ./

--- a/prisma/Dockerfile
+++ b/prisma/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 
 COPY . .
 
+ENV NODE_TLS_REJECT_UNAUTHORIZED='0'
 RUN npm ci --verbose
 
 RUN chmod +x /app/wait-for-it.sh

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider = "prisma-client-js"
-  binaryTargets = ["native", "debian-openssl-3.0.x"]
+  binaryTargets = ["native", "debian-openssl-3.0.x", "linux-arm64-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
api-1        | PrismaClientInitializationError: Prisma Client could not locate the Query Engine for runtime "linux-arm64-openssl-3.0.x".
api-1        |
api-1        | This happened because Prisma Client was generated for "linux-arm64-openssl-1.1.x", but the actual deployment required "linux-arm64-openssl-3.0.x".
api-1        | Add "linux-arm64-openssl-3.0.x" to `binaryTargets` in the "schema.prisma" file and run `prisma generate` after saving it:
api-1        |
api-1        | generator client {
api-1        |   provider      = "prisma-client-js"
api-1        |   binaryTargets = ["native", "debian-openssl-3.0.x", "linux-arm64-openssl-3.0.x"]
api-1        | }