### PR TITLE
feat: preview matching sibling variations for bulk review

### DIFF
--- a/prisma/migrations/20260708120000_add_bulk_approve_variations/migration.sql
+++ b/prisma/migrations/20260708120000_add_bulk_approve_variations/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN "bulkApproveVariations" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "Project" ADD COLUMN "bulkApproveGroupBy" TEXT NOT NULL DEFAULT 'customTags';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,8 @@ model Project {
   autoApproveFeature    Boolean         @default(true)
   imageComparison       ImageComparison @default(pixelmatch)
   imageComparisonConfig String          @default("{ \"threshold\": 0.1, \"ignoreAntialiasing\": true, \"allowDiffDimensions\": false }")
+  bulkApproveVariations Boolean         @default(false)
+  bulkApproveGroupBy    String          @default("customTags")
   builds                Build[]
   TestRun               TestRun[]
   testVariations        TestVariation[]

--- a/prisma/test/seed.spec.ts
+++ b/prisma/test/seed.spec.ts
@@ -16,6 +16,8 @@ const mockDefaultProject = {
   autoApproveFeature: true,
   imageComparison: 'pixelmatch',
   imageComparisonConfig: '{ "threshold": 0.1, "ignoreAntialiasing": true, "allowDiffDimensions": false }',
+  bulkApproveVariations: false,
+  bulkApproveGroupBy: 'customTags',
 } as const;
 
 const mockDefaultUser = {

--- a/src/_data_/index.ts
+++ b/src/_data_/index.ts
@@ -13,6 +13,8 @@ export const TEST_PROJECT: Project = {
   autoApproveFeature: true,
   imageComparisonConfig: '{ "threshold": 0.1, "ignoreAntialiasing": true, "allowDiffDimensions": false }',
   imageComparison: ImageComparison.pixelmatch,
+  bulkApproveVariations: false,
+  bulkApproveGroupBy: 'customTags',
 };
 
 export const TEST_BUILD: Build = {

--- a/src/projects/dto/project.dto.ts
+++ b/src/projects/dto/project.dto.ts
@@ -49,4 +49,12 @@ export class ProjectDto implements Project {
   @ApiProperty()
   @IsJSON()
   imageComparisonConfig: string;
+
+  @ApiProperty()
+  @IsBoolean()
+  bulkApproveVariations: boolean;
+
+  @ApiProperty()
+  @IsString()
+  bulkApproveGroupBy: string;
 }

--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -48,6 +48,8 @@ export class ProjectsService {
         imageComparisonConfig: projectDto.imageComparisonConfig,
         maxBuildAllowed: projectDto.maxBuildAllowed,
         maxBranchLifetime: projectDto.maxBranchLifetime,
+        bulkApproveVariations: projectDto.bulkApproveVariations,
+        bulkApproveGroupBy: projectDto.bulkApproveGroupBy,
       },
     });
   }
@@ -63,6 +65,8 @@ export class ProjectsService {
         maxBuildAllowed: projectDto.maxBuildAllowed,
         maxBranchLifetime: projectDto.maxBranchLifetime,
         imageComparisonConfig: projectDto.imageComparisonConfig,
+        bulkApproveVariations: projectDto.bulkApproveVariations,
+        bulkApproveGroupBy: projectDto.bulkApproveGroupBy,
       },
     });
   }

--- a/src/test-runs/test-runs.controller.ts
+++ b/src/test-runs/test-runs.controller.ts
@@ -23,6 +23,7 @@ import {
   ApiOkResponse,
   ApiConsumes,
   ApiBody,
+  ApiOperation,
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/auth.guard';
 import { Role, TestRun, TestStatus, User } from '@prisma/client';
@@ -78,6 +79,25 @@ export class TestRunsController {
     for (const id of ids) {
       await this.testRunsService.approve(id, merge, false, user.id);
     }
+  }
+
+  @Get('matchingSiblings/:id')
+  @ApiOperation({
+    summary: 'Preview the variation group of a test run for bulk review',
+    description:
+      'Read-only. Returns the reviewed test run together with its sibling variations in the same build ' +
+      '(same name/os/device/browser/viewport/branch, differing only by customTags — e.g. locales) whose ' +
+      'change matches it, plus the siblings left out (skipped) because of a different/additional change. ' +
+      'Nothing is mutated: the reviewer confirms the group and then approves/rejects the chosen ids, so a ' +
+      'similar-looking regression can never be accepted without a human seeing it.',
+  })
+  @ApiParam({ name: 'id', required: true })
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  getMatchingSiblings(
+    @Param('id', new ParseUUIDPipe()) id: string
+  ): Promise<{ variations: TestRunDto[]; skipped: Array<TestRunDto & { reason: string }> }> {
+    return this.testRunsService.getMatchingVariations(id);
   }
 
   @Post('reject')

--- a/src/test-runs/test-runs.service.spec.ts
+++ b/src/test-runs/test-runs.service.spec.ts
@@ -704,4 +704,56 @@ describe('TestRunsService', () => {
       });
     });
   });
+
+  describe('getMatchingVariations', () => {
+    it('matches same-palette, same-size siblings and skips different pattern / far larger change', async () => {
+      const testRun = generateTestRun({ id: 'target', status: TestStatus.unresolved, name: 'Screen A', diffPercent: 12 });
+      const matching = generateTestRun({
+        id: 'match',
+        status: TestStatus.unresolved,
+        name: 'Screen A',
+        customTags: 'locale-a',
+        diffPercent: 12,
+      });
+      const bigger = generateTestRun({
+        id: 'bigger',
+        status: TestStatus.unresolved,
+        name: 'Screen A',
+        customTags: 'locale-b',
+        diffPercent: 30,
+      });
+      const different = generateTestRun({
+        id: 'diff',
+        status: TestStatus.unresolved,
+        name: 'Screen A',
+        customTags: 'locale-c',
+        diffPercent: 12,
+      });
+
+      const testRunFindUniqueMock = jest
+        .fn()
+        .mockResolvedValueOnce({ ...testRun, testVariation: generateTestVariation() });
+      const testRunFindManyMock = jest.fn().mockResolvedValueOnce([matching, bigger, different]);
+      const projectFindUniqueMock = jest
+        .fn()
+        .mockResolvedValueOnce({ bulkApproveVariations: true, bulkApproveGroupBy: 'customTags' });
+      service = await initService({ testRunFindUniqueMock, testRunFindManyMock, projectFindUniqueMock });
+
+      const referenceSignature = [1, 0];
+      service['getChangeSignature'] = jest
+        .fn()
+        .mockResolvedValueOnce(referenceSignature) // target
+        .mockResolvedValueOnce(referenceSignature) // matching sibling
+        .mockResolvedValueOnce(referenceSignature) // bigger sibling (same palette, 2.5x larger change)
+        .mockResolvedValueOnce([0, 1]); // different palette sibling
+
+      const result = await service.getMatchingVariations(testRun.id);
+
+      expect(result.variations.map((variation) => variation.id)).toEqual([testRun.id, matching.id]);
+      expect(result.skipped.map((item) => ({ id: item.id, customTags: item.customTags, reason: item.reason }))).toEqual([
+        { id: bigger.id, customTags: 'locale-b', reason: 'different change size' },
+        { id: different.id, customTags: 'locale-c', reason: 'different change pattern' },
+      ]);
+    });
+  });
 });

--- a/src/test-runs/test-runs.service.spec.ts
+++ b/src/test-runs/test-runs.service.spec.ts
@@ -707,7 +707,12 @@ describe('TestRunsService', () => {
 
   describe('getMatchingVariations', () => {
     it('matches same-palette, same-size siblings and skips different pattern / far larger change', async () => {
-      const testRun = generateTestRun({ id: 'target', status: TestStatus.unresolved, name: 'Screen A', diffPercent: 12 });
+      const testRun = generateTestRun({
+        id: 'target',
+        status: TestStatus.unresolved,
+        name: 'Screen A',
+        diffPercent: 12,
+      });
       const matching = generateTestRun({
         id: 'match',
         status: TestStatus.unresolved,
@@ -750,10 +755,12 @@ describe('TestRunsService', () => {
       const result = await service.getMatchingVariations(testRun.id);
 
       expect(result.variations.map((variation) => variation.id)).toEqual([testRun.id, matching.id]);
-      expect(result.skipped.map((item) => ({ id: item.id, customTags: item.customTags, reason: item.reason }))).toEqual([
-        { id: bigger.id, customTags: 'locale-b', reason: 'different change size' },
-        { id: different.id, customTags: 'locale-c', reason: 'different change pattern' },
-      ]);
+      expect(result.skipped.map((item) => ({ id: item.id, customTags: item.customTags, reason: item.reason }))).toEqual(
+        [
+          { id: bigger.id, customTags: 'locale-b', reason: 'different change size' },
+          { id: different.id, customTags: 'locale-c', reason: 'different change pattern' },
+        ]
+      );
     });
   });
 });

--- a/src/test-runs/test-runs.service.ts
+++ b/src/test-runs/test-runs.service.ts
@@ -14,6 +14,9 @@ import { TestRunDto } from './dto/testRun.dto';
 import { getTestVariationUniqueData } from '../utils';
 import { CompareService } from '../compare/compare.service';
 import { UpdateTestRunDto } from './dto/update-test.dto';
+import { applyIgnoreAreas, parseConfig } from '../compare/utils';
+import { DEFAULT_CONFIG } from '../compare/libs/pixelmatch/pixelmatch.service';
+import { PixelmatchConfig } from '../compare/libs/pixelmatch/pixelmatch.types';
 
 @Injectable()
 export class TestRunsService {
@@ -184,6 +187,13 @@ export class TestRunsService {
       return { testRun, matching: [], skipped: [] };
     }
 
+    // Mirror the project's diff config so the change signature classifies the
+    // same way the normal pixelmatch diff does, rather than a hardcoded threshold.
+    const config: PixelmatchConfig = {
+      ...DEFAULT_CONFIG,
+      ...parseConfig(project.imageComparisonConfig, DEFAULT_CONFIG, this.logger),
+    };
+
     const groupBy = resolveGroupByAxis(project.bulkApproveGroupBy);
     const fixedAxes: Record<string, string | null> = {};
     for (const axis of GROUP_BY_AXES) {
@@ -192,7 +202,7 @@ export class TestRunsService {
       }
     }
 
-    const referenceSignature = await this.getChangeSignature(testRun);
+    const referenceSignature = await this.getChangeSignature(testRun, config);
     const siblings = await this.prismaService.testRun.findMany({
       where: {
         id: { not: testRun.id },
@@ -215,7 +225,7 @@ export class TestRunsService {
     }
 
     for (const sibling of siblings) {
-      const signature = await this.getChangeSignature(sibling);
+      const signature = await this.getChangeSignature(sibling, config);
       if (!signature) {
         skipped.push({ run: sibling, reason: 'no diff to match' });
       } else if (!signaturesMatch(referenceSignature, signature)) {
@@ -254,7 +264,7 @@ export class TestRunsService {
    * took in the new image. Null when there is no baseline, dimensions differ, or
    * nothing changed.
    */
-  private async getChangeSignature(testRun: TestRun): Promise<number[] | null> {
+  private async getChangeSignature(testRun: TestRun, config: PixelmatchConfig): Promise<number[] | null> {
     if (!testRun.baselineName) {
       return null;
     }
@@ -263,7 +273,15 @@ export class TestRunsService {
     if (!baseline || !image || baseline.width !== image.width || baseline.height !== image.height) {
       return null;
     }
-    return changeColorSignature(baseline, image);
+    // Apply ignore areas exactly as the diff does, so masked regions never count
+    // toward the change signature.
+    const ignoreAreas = this.getAllIgnoteAreas(testRun);
+    applyIgnoreAreas(baseline, ignoreAreas);
+    applyIgnoreAreas(image, ignoreAreas);
+    return changeColorSignature(baseline, image, {
+      threshold: config.threshold,
+      includeAA: config.ignoreAntialiasing,
+    });
   }
 
   async setStatus(id: string, status: TestStatus): Promise<TestRun> {
@@ -585,7 +603,8 @@ function downscale(
  */
 function changeColorSignature(
   baselineImage: { data: Buffer; width: number; height: number },
-  checkpointImage: { data: Buffer; width: number; height: number }
+  checkpointImage: { data: Buffer; width: number; height: number },
+  options: { threshold: number; includeAA: boolean }
 ): number[] | null {
   // The signature is a coarse color histogram, so full resolution is wasteful —
   // downscale first to make pixelmatch (CPU-bound, run per variation) much faster.
@@ -594,8 +613,8 @@ function changeColorSignature(
   const { width, height } = baseline;
   const mask = new PNG({ width, height });
   const changedPixels = Pixelmatch(baseline.data, image.data, mask.data, width, height, {
-    threshold: 0.1,
-    includeAA: false,
+    threshold: options.threshold,
+    includeAA: options.includeAA,
     diffMask: true,
   });
   if (changedPixels === 0) {

--- a/src/test-runs/test-runs.service.ts
+++ b/src/test-runs/test-runs.service.ts
@@ -672,4 +672,3 @@ function magnitudesSimilar(a: number | null, b: number | null): boolean {
   }
   return max / min <= MATCH_MAGNITUDE_RATIO;
 }
-

--- a/src/test-runs/test-runs.service.ts
+++ b/src/test-runs/test-runs.service.ts
@@ -1,5 +1,6 @@
 import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
 import { PNG } from 'pngjs';
+import Pixelmatch from 'pixelmatch';
 import { CreateTestRequestDto } from './dto/create-test-request.dto';
 import { IgnoreAreaDto } from './dto/ignore-area.dto';
 import { StaticService } from '../static/static.service';
@@ -150,6 +151,119 @@ export class TestRunsService {
     // update status
     const status = autoApprove ? TestStatus.autoApproved : TestStatus.approved;
     return this.setStatus(id, status);
+  }
+
+  /**
+   * Finds sibling variations of a test run in the same build — same screen
+   * (name) and same test-variation axes except the one configured on the project
+   * as `bulkApproveGroupBy` (customTags by default, i.e. per-locale screenshots).
+   * The feature is opt-in per project via `bulkApproveVariations`.
+   *
+   * Matching uses a position-independent color signature of the changed pixels
+   * (which colors appeared/changed), so it survives per-locale layout shifts —
+   * e.g. a title wrapping to a different number of lines pushes the whole screen
+   * down, but the same change (a moved selection, a recolored button) still
+   * produces the same signature. A loose guard on change size (diffPercent) also
+   * skips variations whose change area is far larger/smaller — a same-palette but
+   * additional/different change — while tolerating per-locale text reflow.
+   * Siblings that don't match, or have no diff to compare, are reported as
+   * skipped. Used by {@link getMatchingVariations}.
+   */
+  private async findMatchingSiblings(
+    id: string
+  ): Promise<{ testRun: TestRun; matching: TestRun[]; skipped: SkippedSibling[] }> {
+    const testRun = await this.findOne(id);
+    if (!testRun) {
+      throw new Error(`No test run found: ${id}`);
+    }
+
+    const project = testRun.projectId
+      ? await this.prismaService.project.findUnique({ where: { id: testRun.projectId } })
+      : null;
+    if (!project?.bulkApproveVariations) {
+      return { testRun, matching: [], skipped: [] };
+    }
+
+    const groupBy = resolveGroupByAxis(project.bulkApproveGroupBy);
+    const fixedAxes: Record<string, string | null> = {};
+    for (const axis of GROUP_BY_AXES) {
+      if (axis !== groupBy) {
+        fixedAxes[axis] = (testRun as unknown as Record<string, string | null>)[axis] ?? null;
+      }
+    }
+
+    const referenceSignature = await this.getChangeSignature(testRun);
+    const siblings = await this.prismaService.testRun.findMany({
+      where: {
+        id: { not: testRun.id },
+        buildId: testRun.buildId,
+        branchName: testRun.branchName,
+        name: testRun.name,
+        ...fixedAxes,
+        status: { in: [TestStatus.unresolved, TestStatus.new] },
+      },
+    });
+
+    const matching: TestRun[] = [];
+    const skipped: SkippedSibling[] = [];
+
+    if (!referenceSignature) {
+      for (const sibling of siblings) {
+        skipped.push({ run: sibling, reason: 'no reference diff' });
+      }
+      return { testRun, matching, skipped };
+    }
+
+    for (const sibling of siblings) {
+      const signature = await this.getChangeSignature(sibling);
+      if (!signature) {
+        skipped.push({ run: sibling, reason: 'no diff to match' });
+      } else if (!signaturesMatch(referenceSignature, signature)) {
+        skipped.push({ run: sibling, reason: 'different change pattern' });
+      } else if (!magnitudesSimilar(testRun.diffPercent, sibling.diffPercent)) {
+        skipped.push({ run: sibling, reason: 'different change size' });
+      } else {
+        matching.push(sibling);
+      }
+    }
+
+    return { testRun, matching, skipped };
+  }
+
+  /**
+   * Returns the group of variations for the reviewed run — the run itself plus
+   * the sibling variations whose change matches it — for the reviewer to confirm
+   * before a bulk approve/reject. Nothing is mutated here: the actual action is
+   * driven by the reviewer's explicit selection (regular approve/reject of the
+   * chosen ids), so a regression that merely looks similar can never be approved
+   * without a human seeing it. `skipped` lists siblings left out of the group
+   * (different/additional change, or no diff to compare).
+   */
+  async getMatchingVariations(
+    id: string
+  ): Promise<{ variations: TestRunDto[]; skipped: Array<TestRunDto & { reason: string }> }> {
+    const { testRun, matching, skipped } = await this.findMatchingSiblings(id);
+    const variations = [testRun, ...matching].map((run) => new TestRunDto(run));
+    const skippedDto = skipped.map((item) => ({ ...new TestRunDto(item.run), reason: item.reason }));
+    return { variations, skipped: skippedDto };
+  }
+
+  /**
+   * Position-independent color signature of the change between a test run's
+   * baseline and image: a normalized histogram of the colors the changed pixels
+   * took in the new image. Null when there is no baseline, dimensions differ, or
+   * nothing changed.
+   */
+  private async getChangeSignature(testRun: TestRun): Promise<number[] | null> {
+    if (!testRun.baselineName) {
+      return null;
+    }
+    const baseline = await this.staticService.getImage(testRun.baselineName);
+    const image = await this.staticService.getImage(testRun.imageName);
+    if (!baseline || !image || baseline.width !== image.width || baseline.height !== image.height) {
+      return null;
+    }
+    return changeColorSignature(baseline, image);
   }
 
   async setStatus(id: string, status: TestStatus): Promise<TestRun> {
@@ -409,3 +523,134 @@ interface AutoApproveProps {
   testVariation: TestVariation;
   testRun: TestRun;
 }
+
+interface SkippedSibling {
+  run: TestRun;
+  reason: string;
+}
+
+// Test-variation axes a project may bulk-approve across (the one that varies
+// within a group). customTags (e.g. locales) is the default.
+const GROUP_BY_AXES = ['customTags', 'os', 'device', 'browser', 'viewport'] as const;
+
+function resolveGroupByAxis(value: string | null | undefined): string {
+  return value && (GROUP_BY_AXES as readonly string[]).includes(value) ? value : 'customTags';
+}
+
+// Colors are quantized to this many levels per RGB channel, giving
+// COLOR_BUCKETS_PER_CHANNEL^3 histogram buckets.
+const COLOR_BUCKETS_PER_CHANNEL = 4;
+// Two changes are considered the same pattern when their color signatures'
+// cosine similarity is at least this value.
+const SIGNATURE_SIMILARITY_THRESHOLD = 0.9;
+
+// Longest side (px) images are downscaled to before computing the color
+// signature — keeps the histogram representative while cutting pixelmatch cost.
+const SIGNATURE_MAX_DIMENSION = 500;
+
+// Nearest-neighbour downscale so the longest side is at most maxDimension.
+// Returns the original when already small enough.
+function downscale(
+  source: { data: Buffer; width: number; height: number },
+  maxDimension: number
+): { data: Buffer; width: number; height: number } {
+  const scale = maxDimension / Math.max(source.width, source.height);
+  if (scale >= 1) {
+    return source;
+  }
+  const width = Math.max(1, Math.round(source.width * scale));
+  const height = Math.max(1, Math.round(source.height * scale));
+  const data: Buffer = Buffer.alloc(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    const sourceY = Math.min(source.height - 1, Math.floor(y / scale));
+    for (let x = 0; x < width; x++) {
+      const sourceX = Math.min(source.width - 1, Math.floor(x / scale));
+      const sourceIndex = (sourceY * source.width + sourceX) * 4;
+      const targetIndex = (y * width + x) * 4;
+      data[targetIndex] = source.data[sourceIndex];
+      data[targetIndex + 1] = source.data[sourceIndex + 1];
+      data[targetIndex + 2] = source.data[sourceIndex + 2];
+      data[targetIndex + 3] = source.data[sourceIndex + 3];
+    }
+  }
+  return { data, width, height };
+}
+
+/**
+ * Position-independent signature of a change: a normalized histogram of the
+ * colors that the changed pixels take in the new image. Because it ignores
+ * *where* the change is, it is robust to per-locale layout shifts (a title
+ * wrapping to a different number of lines, options moving down, etc.) while
+ * still capturing *what* changed (a selection highlight, a recolored button).
+ */
+function changeColorSignature(
+  baselineImage: { data: Buffer; width: number; height: number },
+  checkpointImage: { data: Buffer; width: number; height: number }
+): number[] | null {
+  // The signature is a coarse color histogram, so full resolution is wasteful —
+  // downscale first to make pixelmatch (CPU-bound, run per variation) much faster.
+  const baseline = downscale(baselineImage, SIGNATURE_MAX_DIMENSION);
+  const image = downscale(checkpointImage, SIGNATURE_MAX_DIMENSION);
+  const { width, height } = baseline;
+  const mask = new PNG({ width, height });
+  const changedPixels = Pixelmatch(baseline.data, image.data, mask.data, width, height, {
+    threshold: 0.1,
+    includeAA: false,
+    diffMask: true,
+  });
+  if (changedPixels === 0) {
+    return null;
+  }
+
+  const bucketSize = 256 / COLOR_BUCKETS_PER_CHANNEL;
+  const histogram = new Array(COLOR_BUCKETS_PER_CHANNEL ** 3).fill(0);
+  for (let i = 0; i < width * height; i++) {
+    if (mask.data[i * 4 + 3] === 0) {
+      continue;
+    }
+    const r = Math.min(COLOR_BUCKETS_PER_CHANNEL - 1, Math.floor(image.data[i * 4] / bucketSize));
+    const g = Math.min(COLOR_BUCKETS_PER_CHANNEL - 1, Math.floor(image.data[i * 4 + 1] / bucketSize));
+    const b = Math.min(COLOR_BUCKETS_PER_CHANNEL - 1, Math.floor(image.data[i * 4 + 2] / bucketSize));
+    histogram[r * COLOR_BUCKETS_PER_CHANNEL * COLOR_BUCKETS_PER_CHANNEL + g * COLOR_BUCKETS_PER_CHANNEL + b]++;
+  }
+
+  const total = histogram.reduce((sum, value) => sum + value, 0);
+  if (total === 0) {
+    return null;
+  }
+  return histogram.map((value) => value / total);
+}
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  if (normA === 0 || normB === 0) {
+    return 0;
+  }
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+function signaturesMatch(a: number[], b: number[]): boolean {
+  return cosineSimilarity(a, b) >= SIGNATURE_SIMILARITY_THRESHOLD;
+}
+
+// Same palette but a much larger/smaller change area signals a different or
+// additional change (an extra element changed too), not just per-locale text
+// reflow — which stays well under this ratio. Such variations go to manual review.
+const MATCH_MAGNITUDE_RATIO = 2;
+
+function magnitudesSimilar(a: number | null, b: number | null): boolean {
+  const min = Math.min(a ?? 0, b ?? 0);
+  const max = Math.max(a ?? 0, b ?? 0);
+  if (min <= 0) {
+    return max <= 0;
+  }
+  return max / min <= MATCH_MAGNITUDE_RATIO;
+}
+

--- a/test/projects.e2e-spec.ts
+++ b/test/projects.e2e-spec.ts
@@ -20,6 +20,8 @@ const project: ProjectDto = {
   maxBuildAllowed: 0,
   maxBranchLifetime: 0,
   imageComparisonConfig: '{}',
+  bulkApproveVariations: false,
+  bulkApproveGroupBy: 'customTags',
 };
 
 const projectServiceMock = {


### PR DESCRIPTION
## What

Adds an opt-in "variation group" preview so a reviewer can approve/reject a screen together with its matching sibling variations (e.g. the same screen across locales) in one reviewed action.

- **New endpoint** `GET /test-runs/matchingSiblings/:id` — **read-only**. Returns the reviewed test run plus the sibling runs in the same build that share name / OS / device / browser / viewport / branch and differ only by `customTags`, split into:
  - `variations` — siblings whose change matches the reviewed one;
  - `skipped` — siblings left out (with a `reason`) because their change differs, or there was nothing to compare.

  Nothing is mutated: the client confirms the group and then calls the existing `/approve` or `/reject` with the chosen ids.
- **Matching heuristic** — two signals gate a sibling into `variations`, so a similar-looking regression can never be approved without a human seeing it:
  - color-signature cosine similarity (position-independent histogram of the colors the changed pixels took in the new image);
  - a change-magnitude guard to reject same-hue but differently-sized changes.
- **Project opt-in fields** (default off, non-breaking):
  - `bulkApproveVariations: boolean`
  - `bulkApproveGroupBy: string` (label shown per variation, default `customTags`)
  - Prisma migration `20260708120000_add_bulk_approve_variations`.

## Why

Reviewing large builds one screen at a time is slow when the same visual change lands across many locales/variants. This lets a reviewer confirm the whole group at once, while the two-signal classifier keeps unrelated regressions out of the batch.

## Notes

- Purely additive; existing approve/reject endpoints are unchanged.
- Feature is inert unless a project turns `bulkApproveVariations` on.
- Tests added in `test-runs.service.spec.ts`.

The companion UI lives in a frontend PR.
