### PR TITLE
fix(looks-same): report mismatch percentage

### DIFF
--- a/src/compare/libs/looks-same/looks-same.service.spec.ts
+++ b/src/compare/libs/looks-same/looks-same.service.spec.ts
@@ -59,7 +59,9 @@ describe('getDiff', () => {
     width: 20,
     height: 20,
   });
-  anotherImage.data[0] = 1; // alterate pixel to have it different from 0
+  image.data[3] = 255;
+  anotherImage.data[0] = 255; // alter pixel to have it different from 0
+  anotherImage.data[3] = 255;
 
   it('no baseline', async () => {
     const getImageMock = jest.fn().mockReturnValueOnce(undefined).mockReturnValueOnce(image);
@@ -138,8 +140,8 @@ describe('getDiff', () => {
     expect(result).toStrictEqual({
       status: TestStatus.ok,
       diffName: null,
-      diffPercent: undefined,
-      pixelMisMatchCount: undefined,
+      diffPercent: 0.25,
+      pixelMisMatchCount: 1,
       isSameDimension: true,
     });
   });
@@ -164,8 +166,8 @@ describe('getDiff', () => {
     expect(result).toStrictEqual({
       status: TestStatus.unresolved,
       diffName: null,
-      diffPercent: undefined,
-      pixelMisMatchCount: undefined,
+      diffPercent: 0.25,
+      pixelMisMatchCount: 1,
       isSameDimension: true,
     });
   });
@@ -192,8 +194,8 @@ describe('getDiff', () => {
     expect(result).toStrictEqual({
       status: TestStatus.unresolved,
       diffName: 'diff name',
-      diffPercent: undefined,
-      pixelMisMatchCount: undefined,
+      diffPercent: 0.25,
+      pixelMisMatchCount: 1,
       isSameDimension: true,
     });
   });

--- a/src/compare/libs/looks-same/looks-same.service.ts
+++ b/src/compare/libs/looks-same/looks-same.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { TestStatus } from '@prisma/client';
+import Pixelmatch from 'pixelmatch';
 import { PNG } from 'pngjs';
 import { StaticService } from '../../../static/static.service';
 import { DiffResult } from '../../../test-runs/diffResult';
@@ -54,6 +55,19 @@ export class LookSameService implements ImageComparator {
 
     // compare
     const compareResult = await this.compare(baselineIgnored, imageIgnored, config);
+    result.pixelMisMatchCount = Pixelmatch(
+      baselineIgnored.data,
+      imageIgnored.data,
+      null,
+      baselineIgnored.width,
+      baselineIgnored.height,
+      {
+        includeAA: !config.ignoreAntialiasing,
+        threshold: 0.1,
+      }
+    );
+    result.diffPercent = (result.pixelMisMatchCount * 100) / (imageIgnored.width * imageIgnored.height);
+
     if (compareResult.equal) {
       result.status = TestStatus.ok;
     } else {


### PR DESCRIPTION
## Summary
- calculate `pixelMisMatchCount` for Looks-Same comparisons
- populate `diffPercent` so the review UI does not show `0%` for unresolved visual changes
- retain Looks-Same as the status and diff-image provider

## Why
Looks-Same returns equality, bounds, and clusters, but not a changed-pixel percentage. Consequently unresolved comparisons generate a useful highlighted diff while the review UI misleadingly reports `Diff: 0%`. This adds an informational Pixelmatch count over the same post-ignore-area image buffers.

## Verification
- `npm test -- --runInBand src/compare/libs/looks-same/looks-same.service.spec.ts`
- `npx eslint src/compare/libs/looks-same/looks-same.service.ts src/compare/libs/looks-same/looks-same.service.spec.ts`
- `npx prettier --check src/compare/libs/looks-same/looks-same.service.ts src/compare/libs/looks-same/looks-same.service.spec.ts`