### PR TITLE
fix(looks-same): expose native diff percentage

### DIFF
--- a/src/compare/libs/looks-same/looks-same.service.spec.ts
+++ b/src/compare/libs/looks-same/looks-same.service.spec.ts
@@ -227,4 +227,13 @@ describe('createDiff', () => {
     });
     expect(saveImageMock).toHaveBeenCalledWith('diff', expect.any(Buffer));
   });
+
+  it('rejects an equal result instead of silently omitting the artifact', async () => {
+    const image = new PNG({ width: 1, height: 1 });
+    service = await initService({});
+
+    await expect(service.createDiff(image, image, DEFAULT_CONFIG)).rejects.toThrow(
+      'Cannot create a diff image for an equal Looks-Same result'
+    );
+  });
 });

--- a/src/compare/libs/looks-same/looks-same.service.spec.ts
+++ b/src/compare/libs/looks-same/looks-same.service.spec.ts
@@ -156,7 +156,7 @@ describe('getDiff', () => {
       equal: false,
       differentPixels: 20,
       totalPixels: 400,
-      diffImage: null,
+      diffImage: { createBuffer: jest.fn() },
     });
 
     const result = await service.getDiff(

--- a/src/compare/libs/looks-same/looks-same.service.spec.ts
+++ b/src/compare/libs/looks-same/looks-same.service.spec.ts
@@ -122,7 +122,12 @@ describe('getDiff', () => {
   it('diff not found', async () => {
     const getImageMock = jest.fn().mockReturnValueOnce(image).mockReturnValueOnce(anotherImage);
     service = await initService({ getImageMock });
-    service.compare = jest.fn().mockReturnValueOnce({ equal: true });
+    service.compare = jest.fn().mockReturnValueOnce({
+      equal: true,
+      differentPixels: 0,
+      totalPixels: 400,
+      diffImage: null,
+    });
 
     const result = await service.getDiff(
       {
@@ -138,8 +143,8 @@ describe('getDiff', () => {
     expect(result).toStrictEqual({
       status: TestStatus.ok,
       diffName: null,
-      diffPercent: undefined,
-      pixelMisMatchCount: undefined,
+      diffPercent: 0,
+      pixelMisMatchCount: 0,
       isSameDimension: true,
     });
   });
@@ -147,7 +152,12 @@ describe('getDiff', () => {
   it('diff found', async () => {
     const getImageMock = jest.fn().mockReturnValueOnce(image).mockReturnValueOnce(anotherImage);
     service = await initService({ getImageMock });
-    service.compare = jest.fn().mockReturnValueOnce({ equal: false });
+    service.compare = jest.fn().mockReturnValueOnce({
+      equal: false,
+      differentPixels: 20,
+      totalPixels: 400,
+      diffImage: null,
+    });
 
     const result = await service.getDiff(
       {
@@ -164,17 +174,24 @@ describe('getDiff', () => {
     expect(result).toStrictEqual({
       status: TestStatus.unresolved,
       diffName: null,
-      diffPercent: undefined,
-      pixelMisMatchCount: undefined,
+      diffPercent: 5,
+      pixelMisMatchCount: 20,
       isSameDimension: true,
     });
   });
 
   it('diff found and save diff', async () => {
     const getImageMock = jest.fn().mockReturnValueOnce(image).mockReturnValueOnce(anotherImage);
-    service = await initService({ getImageMock });
-    service.compare = jest.fn().mockReturnValueOnce({ equal: false });
-    service.createDiff = jest.fn().mockReturnValueOnce('diff name');
+    const saveImageMock = jest.fn().mockReturnValueOnce('diff name');
+    const diffBuffer = Buffer.from('diff');
+    const createBuffer = jest.fn().mockReturnValueOnce(diffBuffer);
+    service = await initService({ getImageMock, saveImageMock });
+    service.compare = jest.fn().mockReturnValueOnce({
+      equal: false,
+      differentPixels: 20,
+      totalPixels: 400,
+      diffImage: { createBuffer },
+    });
 
     const result = await service.getDiff(
       {
@@ -188,12 +205,13 @@ describe('getDiff', () => {
     );
 
     expect(service.compare).toHaveBeenCalledWith(image, anotherImage, DEFAULT_CONFIG);
-    expect(service.createDiff).toHaveBeenCalledWith(image, anotherImage, DEFAULT_CONFIG);
+    expect(createBuffer).toHaveBeenCalledWith('png');
+    expect(saveImageMock).toHaveBeenCalledWith('diff', diffBuffer);
     expect(result).toStrictEqual({
       status: TestStatus.unresolved,
       diffName: 'diff name',
-      diffPercent: undefined,
-      pixelMisMatchCount: undefined,
+      diffPercent: 5,
+      pixelMisMatchCount: 20,
       isSameDimension: true,
     });
   });

--- a/src/compare/libs/looks-same/looks-same.service.spec.ts
+++ b/src/compare/libs/looks-same/looks-same.service.spec.ts
@@ -122,12 +122,7 @@ describe('getDiff', () => {
   it('diff not found', async () => {
     const getImageMock = jest.fn().mockReturnValueOnce(image).mockReturnValueOnce(anotherImage);
     service = await initService({ getImageMock });
-    service.compare = jest.fn().mockReturnValueOnce({
-      equal: true,
-      differentPixels: 0,
-      totalPixels: 400,
-      diffImage: null,
-    });
+    service.compare = jest.fn().mockReturnValueOnce({ equal: true });
 
     const result = await service.getDiff(
       {
@@ -143,8 +138,8 @@ describe('getDiff', () => {
     expect(result).toStrictEqual({
       status: TestStatus.ok,
       diffName: null,
-      diffPercent: 0,
-      pixelMisMatchCount: 0,
+      diffPercent: undefined,
+      pixelMisMatchCount: undefined,
       isSameDimension: true,
     });
   });
@@ -152,12 +147,7 @@ describe('getDiff', () => {
   it('diff found', async () => {
     const getImageMock = jest.fn().mockReturnValueOnce(image).mockReturnValueOnce(anotherImage);
     service = await initService({ getImageMock });
-    service.compare = jest.fn().mockReturnValueOnce({
-      equal: false,
-      differentPixels: 20,
-      totalPixels: 400,
-      diffImage: { createBuffer: jest.fn() },
-    });
+    service.compare = jest.fn().mockReturnValueOnce({ equal: false });
 
     const result = await service.getDiff(
       {
@@ -174,23 +164,20 @@ describe('getDiff', () => {
     expect(result).toStrictEqual({
       status: TestStatus.unresolved,
       diffName: null,
-      diffPercent: 5,
-      pixelMisMatchCount: 20,
+      diffPercent: undefined,
+      pixelMisMatchCount: undefined,
       isSameDimension: true,
     });
   });
 
   it('diff found and save diff', async () => {
     const getImageMock = jest.fn().mockReturnValueOnce(image).mockReturnValueOnce(anotherImage);
-    const saveImageMock = jest.fn().mockReturnValueOnce('diff name');
-    const diffBuffer = Buffer.from('diff');
-    const createBuffer = jest.fn().mockReturnValueOnce(diffBuffer);
-    service = await initService({ getImageMock, saveImageMock });
-    service.compare = jest.fn().mockReturnValueOnce({
-      equal: false,
-      differentPixels: 20,
-      totalPixels: 400,
-      diffImage: { createBuffer },
+    service = await initService({ getImageMock });
+    service.compare = jest.fn().mockReturnValueOnce({ equal: false });
+    service.createDiff = jest.fn().mockReturnValueOnce({
+      diffName: 'diff name',
+      diffPercent: 5,
+      pixelMisMatchCount: 20,
     });
 
     const result = await service.getDiff(
@@ -205,8 +192,7 @@ describe('getDiff', () => {
     );
 
     expect(service.compare).toHaveBeenCalledWith(image, anotherImage, DEFAULT_CONFIG);
-    expect(createBuffer).toHaveBeenCalledWith('png');
-    expect(saveImageMock).toHaveBeenCalledWith('diff', diffBuffer);
+    expect(service.createDiff).toHaveBeenCalledWith(image, anotherImage, DEFAULT_CONFIG);
     expect(result).toStrictEqual({
       status: TestStatus.unresolved,
       diffName: 'diff name',
@@ -214,5 +200,31 @@ describe('getDiff', () => {
       pixelMisMatchCount: 20,
       isSameDimension: true,
     });
+  });
+});
+
+describe('createDiff', () => {
+  it('returns metrics from the generated Looks-Same diff', async () => {
+    const baseline = new PNG({ width: 2, height: 1 });
+    const image = new PNG({ width: 2, height: 1 });
+    baseline.data.fill(255);
+    image.data.fill(255);
+    image.data[0] = 0;
+
+    const saveImageMock = jest.fn().mockReturnValueOnce('diff name');
+    service = await initService({ saveImageMock });
+
+    const result = await service.createDiff(baseline, image, {
+      ...DEFAULT_CONFIG,
+      strict: true,
+      ignoreAntialiasing: false,
+    });
+
+    expect(result).toStrictEqual({
+      diffName: 'diff name',
+      diffPercent: 50,
+      pixelMisMatchCount: 1,
+    });
+    expect(saveImageMock).toHaveBeenCalledWith('diff', expect.any(Buffer));
   });
 });

--- a/src/compare/libs/looks-same/looks-same.service.ts
+++ b/src/compare/libs/looks-same/looks-same.service.ts
@@ -54,12 +54,16 @@ export class LookSameService implements ImageComparator {
 
     // compare
     const compareResult = await this.compare(baselineIgnored, imageIgnored, config);
+    result.pixelMisMatchCount = compareResult.differentPixels;
+    result.diffPercent =
+      compareResult.totalPixels > 0 ? (compareResult.differentPixels * 100) / compareResult.totalPixels : 0;
+
     if (compareResult.equal) {
       result.status = TestStatus.ok;
     } else {
       result.status = TestStatus.unresolved;
-      if (data.saveDiffAsFile) {
-        result.diffName = await this.createDiff(baselineIgnored, imageIgnored, config);
+      if (data.saveDiffAsFile && compareResult.diffImage) {
+        result.diffName = await this.staticService.saveImage('diff', await compareResult.diffImage.createBuffer('png'));
       }
     }
 
@@ -67,28 +71,14 @@ export class LookSameService implements ImageComparator {
   }
 
   async compare(baseline: PNG, image: PNG, config: LooksSameConfig): Promise<LookSameResult | undefined> {
-    const diffResult = await looksSame(PNG.sync.write(baseline), PNG.sync.write(image), config).catch((error) => {
+    const diffResult = await looksSame(PNG.sync.write(baseline), PNG.sync.write(image), {
+      ...config,
+      createDiffImage: true,
+    }).catch((error) => {
       this.logger.error(error.message);
     });
     if (diffResult) {
       return diffResult;
-    }
-    return undefined;
-  }
-
-  async createDiff(baseline: PNG, image: PNG, config: LooksSameConfig): Promise<string | undefined> {
-    const buffer = await looksSame
-      .createDiff({
-        reference: PNG.sync.write(baseline),
-        current: PNG.sync.write(image),
-        highlightColor: '#ff00ff',
-        ...config,
-      })
-      .catch((error) => {
-        this.logger.error(error.message);
-      });
-    if (buffer) {
-      return this.staticService.saveImage('diff', buffer);
     }
     return undefined;
   }

--- a/src/compare/libs/looks-same/looks-same.service.ts
+++ b/src/compare/libs/looks-same/looks-same.service.ts
@@ -62,7 +62,7 @@ export class LookSameService implements ImageComparator {
       result.status = TestStatus.ok;
     } else {
       result.status = TestStatus.unresolved;
-      if (data.saveDiffAsFile && compareResult.diffImage) {
+      if (data.saveDiffAsFile) {
         result.diffName = await this.staticService.saveImage('diff', await compareResult.diffImage.createBuffer('png'));
       }
     }

--- a/src/compare/libs/looks-same/looks-same.service.ts
+++ b/src/compare/libs/looks-same/looks-same.service.ts
@@ -60,9 +60,9 @@ export class LookSameService implements ImageComparator {
       result.status = TestStatus.unresolved;
       if (data.saveDiffAsFile) {
         const diff = await this.createDiff(baselineIgnored, imageIgnored, config);
-        if (diff) {
-          Object.assign(result, diff);
-        }
+        result.diffName = diff.diffName;
+        result.diffPercent = diff.diffPercent;
+        result.pixelMisMatchCount = diff.pixelMisMatchCount;
       }
     }
 
@@ -83,16 +83,14 @@ export class LookSameService implements ImageComparator {
     baseline: PNG,
     image: PNG,
     config: LooksSameConfig
-  ): Promise<Pick<DiffResult, 'diffName' | 'diffPercent' | 'pixelMisMatchCount'> | undefined> {
+  ): Promise<Pick<DiffResult, 'diffName' | 'diffPercent' | 'pixelMisMatchCount'>> {
     const diffResult = await looksSame(PNG.sync.write(baseline), PNG.sync.write(image), {
       ...config,
       createDiffImage: true,
-    }).catch((error) => {
-      this.logger.error(error.message);
     });
 
-    if (!diffResult || diffResult.equal) {
-      return undefined;
+    if (diffResult.equal) {
+      throw new Error('Cannot create a diff image for an equal Looks-Same result');
     }
 
     return {

--- a/src/compare/libs/looks-same/looks-same.service.ts
+++ b/src/compare/libs/looks-same/looks-same.service.ts
@@ -54,16 +54,15 @@ export class LookSameService implements ImageComparator {
 
     // compare
     const compareResult = await this.compare(baselineIgnored, imageIgnored, config);
-    result.pixelMisMatchCount = compareResult.differentPixels;
-    result.diffPercent =
-      compareResult.totalPixels > 0 ? (compareResult.differentPixels * 100) / compareResult.totalPixels : 0;
-
     if (compareResult.equal) {
       result.status = TestStatus.ok;
     } else {
       result.status = TestStatus.unresolved;
       if (data.saveDiffAsFile) {
-        result.diffName = await this.staticService.saveImage('diff', await compareResult.diffImage.createBuffer('png'));
+        const diff = await this.createDiff(baselineIgnored, imageIgnored, config);
+        if (diff) {
+          Object.assign(result, diff);
+        }
       }
     }
 
@@ -71,15 +70,35 @@ export class LookSameService implements ImageComparator {
   }
 
   async compare(baseline: PNG, image: PNG, config: LooksSameConfig): Promise<LookSameResult | undefined> {
-    const diffResult = await looksSame(PNG.sync.write(baseline), PNG.sync.write(image), {
-      ...config,
-      createDiffImage: true,
-    }).catch((error) => {
+    const diffResult = await looksSame(PNG.sync.write(baseline), PNG.sync.write(image), config).catch((error) => {
       this.logger.error(error.message);
     });
     if (diffResult) {
       return diffResult;
     }
     return undefined;
+  }
+
+  async createDiff(
+    baseline: PNG,
+    image: PNG,
+    config: LooksSameConfig
+  ): Promise<Pick<DiffResult, 'diffName' | 'diffPercent' | 'pixelMisMatchCount'> | undefined> {
+    const diffResult = await looksSame(PNG.sync.write(baseline), PNG.sync.write(image), {
+      ...config,
+      createDiffImage: true,
+    }).catch((error) => {
+      this.logger.error(error.message);
+    });
+
+    if (!diffResult || diffResult.equal) {
+      return undefined;
+    }
+
+    return {
+      diffName: await this.staticService.saveImage('diff', await diffResult.diffImage.createBuffer('png')),
+      diffPercent: diffResult.totalPixels > 0 ? (diffResult.differentPixels * 100) / diffResult.totalPixels : 0,
+      pixelMisMatchCount: diffResult.differentPixels,
+    };
   }
 }

--- a/src/compare/libs/looks-same/looks-same.types.ts
+++ b/src/compare/libs/looks-same/looks-same.types.ts
@@ -57,4 +57,18 @@ export type LookSameResult = {
    * diff clusters for not equal images
    */
   diffClusters?: CoordBounds[];
+  /**
+   * number of pixels considered different
+   */
+  differentPixels: number;
+  /**
+   * number of pixels compared
+   */
+  totalPixels: number;
+  /**
+   * generated diff image when createDiffImage is enabled
+   */
+  diffImage: {
+    createBuffer(extension: 'png' | 'raw'): Promise<Buffer>;
+  } | null;
 };

--- a/src/compare/libs/looks-same/looks-same.types.ts
+++ b/src/compare/libs/looks-same/looks-same.types.ts
@@ -44,7 +44,7 @@ export interface CoordBounds {
   bottom: number;
 }
 
-type LookSameBaseResult = {
+export type LookSameResult = {
   /**
    * true if images are equal, false - otherwise
    */
@@ -57,29 +57,4 @@ type LookSameBaseResult = {
    * diff clusters for not equal images
    */
   diffClusters?: CoordBounds[];
-  /**
-   * number of pixels considered different
-   */
-  differentPixels: number;
-  /**
-   * number of pixels compared
-   */
-  totalPixels: number;
-  /**
-   * generated diff image when createDiffImage is enabled
-   */
 };
-
-type DiffImage = {
-  createBuffer(extension: 'png' | 'raw'): Promise<Buffer>;
-};
-
-export type LookSameResult =
-  | (LookSameBaseResult & {
-      equal: true;
-      diffImage: null;
-    })
-  | (LookSameBaseResult & {
-      equal: false;
-      diffImage: DiffImage;
-    });

--- a/src/compare/libs/looks-same/looks-same.types.ts
+++ b/src/compare/libs/looks-same/looks-same.types.ts
@@ -44,7 +44,7 @@ export interface CoordBounds {
   bottom: number;
 }
 
-export type LookSameResult = {
+type LookSameBaseResult = {
   /**
    * true if images are equal, false - otherwise
    */
@@ -68,7 +68,18 @@ export type LookSameResult = {
   /**
    * generated diff image when createDiffImage is enabled
    */
-  diffImage: {
-    createBuffer(extension: 'png' | 'raw'): Promise<Buffer>;
-  } | null;
 };
+
+type DiffImage = {
+  createBuffer(extension: 'png' | 'raw'): Promise<Buffer>;
+};
+
+export type LookSameResult =
+  | (LookSameBaseResult & {
+      equal: true;
+      diffImage: null;
+    })
+  | (LookSameBaseResult & {
+      equal: false;
+      diffImage: DiffImage;
+    });


### PR DESCRIPTION
## Summary
- preserve the existing lightweight Looks-Same boolean comparison path
- when VRT already requests a saved diff, use Looks-Same native `createDiffImage` output
- persist `differentPixels / totalPixels` as `diffPercent` alongside that artifact

## Why
Looks-Same already calculates `differentPixels` and `totalPixels` while producing a diff image. VRT currently discards those metrics, so unresolved comparisons display `Diff: 0%`. The metrics stay strictly in the existing `saveDiffAsFile` path: ordinary comparisons do not allocate a diff image or change behavior.

## Verification
- real Looks-Same diff test asserts image artifact, mismatch count, and 50% result
- `npm test -- --runInBand src/compare/libs/looks-same/looks-same.service.spec.ts`
- `npm run build`
- focused ESLint and Prettier checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Diff results now include the diff name, percentage difference, and mismatched pixel count.
  * Diff images are saved consistently when requested.
  * Comparing identical images now reports an explicit error instead of silently omitting the diff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->