### PR TITLE
feat: filter builds by CI build id

### DIFF
--- a/src/builds/builds.controller.ts
+++ b/src/builds/builds.controller.ts
@@ -16,7 +16,7 @@ import {
 } from '@nestjs/common';
 import { BuildsService } from './builds.service';
 import { JwtAuthGuard } from '../auth/guards/auth.guard';
-import { ApiBearerAuth, ApiTags, ApiSecurity, ApiOkResponse } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags, ApiSecurity, ApiOkResponse, ApiQuery } from '@nestjs/swagger';
 import { CreateBuildDto } from './dto/build-create.dto';
 import { ApiGuard } from '../auth/guards/api.guard';
 import { Build, Role } from '@prisma/client';
@@ -39,14 +39,16 @@ export class BuildsController {
 
   @Get()
   @ApiOkResponse({ type: PaginatedBuildDto })
+  @ApiQuery({ name: 'ciBuildId', required: false, description: 'Case insensitive substring of the CI build id' })
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
   get(
     @Query('projectId', new ParseUUIDPipe()) projectId: string,
     @Query('take', new ParseIntPipe()) take: number,
-    @Query('skip', new ParseIntPipe()) skip: number
+    @Query('skip', new ParseIntPipe()) skip: number,
+    @Query('ciBuildId') ciBuildId?: string
   ): Promise<PaginatedBuildDto> {
-    return this.buildsService.findMany(projectId, take, skip);
+    return this.buildsService.findMany(projectId, take, skip, ciBuildId);
   }
 
   @Get(':id')

--- a/src/builds/builds.service.spec.ts
+++ b/src/builds/builds.service.spec.ts
@@ -3,7 +3,7 @@ import { BuildsService } from './builds.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { TestRunsService } from '../test-runs/test-runs.service';
 import { EventsGateway } from '../shared/events/events.gateway';
-import { Build, TestRun, TestStatus } from '@prisma/client';
+import { Build, Prisma, TestRun, TestStatus } from '@prisma/client';
 import { mocked, MockedObject } from 'jest-mock';
 import { BuildDto } from './dto/build.dto';
 import { ProjectsService } from '../projects/projects.service';
@@ -148,6 +148,46 @@ describe('BuildsService', () => {
       total: 33,
       take: 10,
       skip: 20,
+    });
+  });
+
+  it('findMany filtered by ciBuildId', async () => {
+    const buildFindManyMock = jest.fn().mockResolvedValueOnce([build]);
+    const buildCountMock = jest.fn().mockResolvedValueOnce(1);
+    const projectId = 'someId';
+    mocked(BuildDto).mockReturnValueOnce(buildDto as MockedObject<BuildDto>);
+    service = await initService({ buildFindManyMock, buildCountMock });
+
+    await service.findMany(projectId, 10, 0, 'Onboarding');
+
+    const where = {
+      projectId,
+      ciBuildId: { contains: 'Onboarding', mode: Prisma.QueryMode.insensitive },
+    };
+    expect(buildCountMock).toHaveBeenCalledWith({ where });
+    expect(buildFindManyMock).toHaveBeenCalledWith({
+      take: 10,
+      skip: 0,
+      orderBy: { createdAt: 'desc' },
+      where,
+    });
+  });
+
+  it('findMany ignores an empty ciBuildId', async () => {
+    const buildFindManyMock = jest.fn().mockResolvedValueOnce([build]);
+    const buildCountMock = jest.fn().mockResolvedValueOnce(33);
+    const projectId = 'someId';
+    mocked(BuildDto).mockReturnValueOnce(buildDto as MockedObject<BuildDto>);
+    service = await initService({ buildFindManyMock, buildCountMock });
+
+    await service.findMany(projectId, 10, 0, '');
+
+    expect(buildCountMock).toHaveBeenCalledWith({ where: { projectId } });
+    expect(buildFindManyMock).toHaveBeenCalledWith({
+      take: 10,
+      skip: 0,
+      orderBy: { createdAt: 'desc' },
+      where: { projectId },
     });
   });
 

--- a/src/builds/builds.service.ts
+++ b/src/builds/builds.service.ts
@@ -32,11 +32,18 @@ export class BuildsService {
     });
   }
 
-  async findMany(projectId: string, take: number, skip: number): Promise<PaginatedBuildDto> {
+  async findMany(projectId: string, take: number, skip: number, ciBuildId?: string): Promise<PaginatedBuildDto> {
+    const where: Prisma.BuildWhereInput = {
+      projectId,
+      ...(ciBuildId && {
+        ciBuildId: { contains: ciBuildId, mode: Prisma.QueryMode.insensitive },
+      }),
+    };
+
     const [total, buildList] = await Promise.all([
-      this.prismaService.build.count({ where: { projectId } }),
+      this.prismaService.build.count({ where }),
       this.prismaService.build.findMany({
-        where: { projectId },
+        where,
         take,
         skip,
         orderBy: { createdAt: 'desc' },


### PR DESCRIPTION
## What & why

`GET /builds` only supports pagination, so finding a specific run in a project with a long history means paging through the build list. This adds an optional server-side filter on the CI build id, which the UI can use to search the whole history instead of the loaded page.

## Changes

- **New optional `ciBuildId` query param** on `GET /builds`. It matches a case-insensitive substring (`contains` + `mode: insensitive`).
- The `where` clause is built once and passed to **both** `count` and `findMany`, so `total` stays consistent with the filtered page and pagination doesn't lie.
- An empty or omitted value means no filter, so existing clients (CI agents, SDKs) are unaffected. Documented in Swagger with `@ApiQuery({ required: false })`.

No schema change and no new index: `ILIKE '%x%'` can't use the existing `@@unique([projectId, ciBuildId])` b-tree anyway, and the scan is bounded by one project's builds (default `maxBuildAllowed` is 100).

## Notes for reviewers

Prisma's `contains` does not escape LIKE wildcards, so `%` and `_` typed by a user act as wildcards. That's a false-positive match, not an injection — the query stays parameterised. Happy to escape them if you'd prefer strict literal matching.

## Testing

- `npm run build` and `eslint` clean.
- Unit tests: **175/175** pass, including two new `findMany` cases (filter applied to both queries; empty value ignored).
- Verified against a local instance with 40 builds: no filter → 40, `REGRESSION` → 10 (case-insensitive), `19.5` → 2, no match → 0, empty value → unfiltered, invalid `projectId` → 400.

## Screenshots

https://github.com/user-attachments/assets/b8dd9883-5a5b-4547-b80d-ad94c474a3cf

<img width="823" height="589" alt="Screenshot 2026-07-27 at 11 11 53" src="https://github.com/user-attachments/assets/3f483899-f080-453c-a1e9-34a970054f2a" />
<img width="1025" height="582" alt="Screenshot 2026-07-27 at 11 12 10" src="https://github.com/user-attachments/assets/59c0bffd-cf91-4949-a9e0-f6035a220603" />
<img width="1032" height="594" alt="Screenshot 2026-07-27 at 11 12 19" src="https://github.com/user-attachments/assets/1e85a428-ba21-4cf0-884a-2ca0efeaa8a3" />