### PR TITLE
ci: gate SonarCloud on env token, not secrets in if

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     # https://github.com/actions/runner-images#available-images
     runs-on: ubuntu-22.04
+    env:
+      SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -66,10 +68,8 @@ jobs:
         run: docker compose -f docker-compose.yml -f docker-compose.ldap.yml down
 
       - name: SonarCloud Scan
-        if: ${{ secrets.SONARCLOUD_TOKEN != '' }}
+        if: env.SONAR_TOKEN != ''
         uses: SonarSource/sonarqube-scan-action@v6
-        env:
-          SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
 
   test-migrations:
     # See: https://github.com/Visual-Regression-Tracker/backend/issues/273


### PR DESCRIPTION
secrets is not allowed in step if expressions, so map the token to job env and skip the scan when it is empty (e.g. fork PRs).