### PR TITLE
fix: serve image bytes from the API for bulk download

### DIFF
--- a/src/static/aws/s3.service.ts
+++ b/src/static/aws/s3.service.ts
@@ -36,12 +36,14 @@ export class AWSS3Service implements Static {
 
   async getImage(fileName: string): Promise<PNGWithMetadata> {
     if (!fileName) return null;
-    const imageBuffer = await this.getImageBuffer(fileName);
-    if (!imageBuffer) return undefined;
     try {
+      // the comparison pipeline treats an unreadable image as a missing
+      // baseline, so storage failures stay contained here
+      const imageBuffer = await this.getImageBuffer(fileName);
+      if (!imageBuffer) return undefined;
       return PNG.sync.read(imageBuffer);
     } catch (ex) {
-      this.logger.error(`Error from read : Cannot decode image: ${fileName}. ${ex}`);
+      this.logger.error(`Error from read : Cannot get image: ${fileName}. ${ex}`);
     }
   }
 
@@ -54,7 +56,12 @@ export class AWSS3Service implements Static {
       return Buffer.concat(await stream.toArray());
     } catch (ex) {
       this.logger.error(`Error from read : Cannot get image: ${fileName}. ${ex}`);
-      return null;
+      // only a missing object means "no image"; credentials, throttling and
+      // network failures have to stay errors instead of reading as absence
+      if (ex?.name === 'NoSuchKey' || ex?.$metadata?.httpStatusCode === 404) {
+        return null;
+      }
+      throw ex;
     }
   }
 

--- a/src/static/aws/s3.service.ts
+++ b/src/static/aws/s3.service.ts
@@ -36,13 +36,25 @@ export class AWSS3Service implements Static {
 
   async getImage(fileName: string): Promise<PNGWithMetadata> {
     if (!fileName) return null;
+    const imageBuffer = await this.getImageBuffer(fileName);
+    if (!imageBuffer) return undefined;
+    try {
+      return PNG.sync.read(imageBuffer);
+    } catch (ex) {
+      this.logger.error(`Error from read : Cannot decode image: ${fileName}. ${ex}`);
+    }
+  }
+
+  async getImageBuffer(fileName: string): Promise<Buffer | null> {
+    if (!fileName) return null;
     try {
       const command = new GetObjectCommand({ Bucket: this.AWS_S3_BUCKET_NAME, Key: fileName });
       const s3Response = await this.s3Client.send(command);
       const stream = s3Response.Body as Readable;
-      return PNG.sync.read(Buffer.concat(await stream.toArray()));
+      return Buffer.concat(await stream.toArray());
     } catch (ex) {
       this.logger.error(`Error from read : Cannot get image: ${fileName}. ${ex}`);
+      return null;
     }
   }
 

--- a/src/static/hdd/hdd.service.spec.ts
+++ b/src/static/hdd/hdd.service.spec.ts
@@ -7,7 +7,16 @@ describe('HddService', () => {
     expect(service.getImagePath('ABC123.screenshot.png')).toMatch(/imageUploads\/ABC123\.screenshot\.png$/);
   });
 
-  it.each(['../../etc/passwd', '../outside.png', '/etc/passwd', 'nested/../../outside.png', '..'])(
+  // a name may begin with dots without climbing out of the directory
+  it.each(['..thumbnail.png', '...png', '.hidden.png'])(
+    'resolves a dotted name inside the directory: %s',
+    (imageName) => {
+      expect(service.getImagePath(imageName)).toContain('imageUploads');
+      expect(() => service.getImagePath(imageName)).not.toThrow();
+    }
+  );
+
+  it.each(['../../etc/passwd', '../outside.png', '/etc/passwd', 'nested/../../outside.png', '..', '.'])(
     'rejects an image name pointing outside the image directory: %s',
     (imageName) => {
       expect(() => service.getImagePath(imageName)).toThrow(/outside of the image directory/);

--- a/src/static/hdd/hdd.service.spec.ts
+++ b/src/static/hdd/hdd.service.spec.ts
@@ -1,0 +1,24 @@
+import { HddService } from './hdd.service';
+
+describe('HddService', () => {
+  const service = new HddService();
+
+  it('resolves a plain image name inside the image directory', () => {
+    expect(service.getImagePath('ABC123.screenshot.png')).toMatch(/imageUploads\/ABC123\.screenshot\.png$/);
+  });
+
+  it.each(['../../etc/passwd', '../outside.png', '/etc/passwd', 'nested/../../outside.png', '..'])(
+    'rejects an image name pointing outside the image directory: %s',
+    (imageName) => {
+      expect(() => service.getImagePath(imageName)).toThrow(/outside of the image directory/);
+    }
+  );
+
+  it('returns null for a missing image', async () => {
+    await expect(service.getImageBuffer('definitely-missing.png')).resolves.toBeNull();
+  });
+
+  it('propagates a traversal attempt instead of reading the file', async () => {
+    await expect(service.getImageBuffer('../../etc/passwd')).rejects.toThrow(/outside of the image directory/);
+  });
+});

--- a/src/static/hdd/hdd.service.ts
+++ b/src/static/hdd/hdd.service.ts
@@ -47,6 +47,16 @@ export class HddService implements Static {
     }
   }
 
+  async getImageBuffer(imageName: string): Promise<Buffer | null> {
+    if (!imageName) return null;
+    try {
+      return readFileSync(this.getImagePath(imageName));
+    } catch (ex) {
+      this.logger.error(`Cannot get image: ${imageName}. ${ex}`);
+      return null;
+    }
+  }
+
   async deleteImage(imageName: string): Promise<boolean> {
     if (!imageName) return;
     return new Promise((resolvePromise) => {

--- a/src/static/hdd/hdd.service.ts
+++ b/src/static/hdd/hdd.service.ts
@@ -23,8 +23,12 @@ export class HddService implements Static {
     const imagePath = path.resolve(root, imageName);
     // image names reach here straight from the request, so a traversal value
     // would otherwise read any file the process can see
+    // only a leading parent-directory step means the name climbs out: a file
+    // whose name merely starts with dots stays inside
     const relativeToRoot = path.relative(root, imagePath);
-    if (!relativeToRoot || relativeToRoot.startsWith('..') || path.isAbsolute(relativeToRoot)) {
+    const climbsOut =
+      relativeToRoot === '..' || relativeToRoot.startsWith(`..${path.sep}`) || path.isAbsolute(relativeToRoot);
+    if (!relativeToRoot || climbsOut) {
       throw new Error(`Image name outside of the image directory: ${imageName}`);
     }
     return imagePath;

--- a/src/static/hdd/hdd.service.ts
+++ b/src/static/hdd/hdd.service.ts
@@ -19,7 +19,15 @@ export class HddService implements Static {
 
   getImagePath(imageName: string): string {
     this.ensureDirectoryExistence(HDD_IMAGE_PATH);
-    return path.resolve(HDD_IMAGE_PATH, imageName);
+    const root = path.resolve(HDD_IMAGE_PATH);
+    const imagePath = path.resolve(root, imageName);
+    // image names reach here straight from the request, so a traversal value
+    // would otherwise read any file the process can see
+    const relativeToRoot = path.relative(root, imagePath);
+    if (!relativeToRoot || relativeToRoot.startsWith('..') || path.isAbsolute(relativeToRoot)) {
+      throw new Error(`Image name outside of the image directory: ${imageName}`);
+    }
+    return imagePath;
   }
 
   getImageUrl(imageName: string): Promise<string> {
@@ -53,7 +61,12 @@ export class HddService implements Static {
       return readFileSync(this.getImagePath(imageName));
     } catch (ex) {
       this.logger.error(`Cannot get image: ${imageName}. ${ex}`);
-      return null;
+      // an absent file is the only case that means "no image"; a permission or
+      // I/O failure has to stay an error rather than read as a missing image
+      if (ex?.code === 'ENOENT') {
+        return null;
+      }
+      throw ex;
     }
   }
 

--- a/src/static/static.controller.spec.ts
+++ b/src/static/static.controller.spec.ts
@@ -1,0 +1,61 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Response } from 'express';
+import { StaticController } from './static.controller';
+import { StaticService } from './static.service';
+
+const initController = async (getImageBufferMock = jest.fn()) => {
+  const module: TestingModule = await Test.createTestingModule({
+    controllers: [StaticController],
+    providers: [
+      {
+        provide: StaticService,
+        useValue: { getImageBuffer: getImageBufferMock, getImageUrl: jest.fn() },
+      },
+    ],
+  }).compile();
+
+  return module.get<StaticController>(StaticController);
+};
+
+const responseMock = () => {
+  const res = { set: jest.fn(), send: jest.fn() };
+  return res as unknown as Response & { set: jest.Mock; send: jest.Mock };
+};
+
+describe('download', () => {
+  it('answers with the image bytes', async () => {
+    const imageBuffer = Buffer.from([1, 2, 3]);
+    const getImageBufferMock = jest.fn().mockResolvedValueOnce(imageBuffer);
+    const controller = await initController(getImageBufferMock);
+    const res = responseMock();
+
+    await controller.download('image.png', res);
+
+    expect(getImageBufferMock).toHaveBeenCalledWith('image.png');
+    expect(res.set).toHaveBeenCalledWith({
+      'Content-Type': 'image/png',
+      'Content-Disposition': 'attachment; filename="image.png"',
+    });
+    expect(res.send).toHaveBeenCalledWith(imageBuffer);
+  });
+
+  it('answers 404 for an image that is not there', async () => {
+    const getImageBufferMock = jest.fn().mockResolvedValueOnce(null);
+    const controller = await initController(getImageBufferMock);
+
+    await expect(controller.download('missing.png', responseMock())).rejects.toThrow(NotFoundException);
+  });
+
+  // a name carrying a path could otherwise read any file the process can see
+  it.each(['../../etc/passwd', '..', '.', '', 'nested/image.png', '/etc/passwd'])(
+    'rejects %p without touching storage',
+    async (fileName) => {
+      const getImageBufferMock = jest.fn();
+      const controller = await initController(getImageBufferMock);
+
+      await expect(controller.download(fileName, responseMock())).rejects.toThrow(BadRequestException);
+      expect(getImageBufferMock).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/src/static/static.controller.ts
+++ b/src/static/static.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Logger, Param, Res } from '@nestjs/common';
+import { Controller, Get, Logger, NotFoundException, Param, Res } from '@nestjs/common';
 import { Response } from 'express';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { StaticService } from './static.service';
@@ -19,5 +19,25 @@ export class StaticController {
       this.logger.error('Error fetching file from S3:' + fileName, error);
       res.status(500).send('Error occurred while getting the file.');
     }
+  }
+
+  /**
+   * Serves the image bytes from this origin instead of redirecting to storage.
+   * Redirected pre-signed S3 URLs carry no CORS headers, so a browser `fetch`
+   * (used to build the bulk download zip) is blocked; an `<img>` tag is not,
+   * which is why display keeps using the redirect above.
+   */
+  @Get('/:fileName/download')
+  @ApiOkResponse()
+  async download(@Param('fileName') fileName: string, @Res() res: Response) {
+    const imageBuffer = await this.staticService.getImageBuffer(fileName);
+    if (!imageBuffer) {
+      throw new NotFoundException(`Image not found: ${fileName}`);
+    }
+    res.set({
+      'Content-Type': 'image/png',
+      'Content-Disposition': `attachment; filename="${fileName}"`,
+    });
+    res.send(imageBuffer);
   }
 }

--- a/src/static/static.controller.ts
+++ b/src/static/static.controller.ts
@@ -32,8 +32,10 @@ export class StaticController {
   @ApiOkResponse()
   async download(@Param('fileName') fileName: string, @Res() res: Response) {
     // a stored image is always a plain file name, so anything carrying a path
-    // is rejected before it reaches storage
-    if (!fileName || fileName !== basename(fileName)) {
+    // is rejected before it reaches storage. basename keeps '.' and '..' as
+    // they are, so both are named here rather than reaching a backend that
+    // would answer 500 for them, or ask storage for a directory.
+    if (!fileName || fileName === '.' || fileName === '..' || fileName !== basename(fileName)) {
       throw new BadRequestException('Invalid image name');
     }
 

--- a/src/static/static.controller.ts
+++ b/src/static/static.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Logger, NotFoundException, Param, Res } from '@nestjs/common';
+import { BadRequestException, Controller, Get, Logger, NotFoundException, Param, Res } from '@nestjs/common';
 import { Response } from 'express';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { basename } from 'path';
 import { StaticService } from './static.service';
 
 @ApiTags('images')
@@ -30,6 +31,12 @@ export class StaticController {
   @Get('/:fileName/download')
   @ApiOkResponse()
   async download(@Param('fileName') fileName: string, @Res() res: Response) {
+    // a stored image is always a plain file name, so anything carrying a path
+    // is rejected before it reaches storage
+    if (!fileName || fileName !== basename(fileName)) {
+      throw new BadRequestException('Invalid image name');
+    }
+
     const imageBuffer = await this.staticService.getImageBuffer(fileName);
     if (!imageBuffer) {
       throw new NotFoundException(`Image not found: ${fileName}`);

--- a/src/static/static.interface.ts
+++ b/src/static/static.interface.ts
@@ -3,6 +3,7 @@ import { PNGWithMetadata } from 'pngjs';
 export interface Static {
   saveImage(type: 'screenshot' | 'diff' | 'baseline', imageBuffer: Buffer): Promise<string>;
   getImage(fileName: string): Promise<PNGWithMetadata>;
+  getImageBuffer(fileName: string): Promise<Buffer | null>;
   deleteImage(imageName: string): Promise<boolean>;
   getImageUrl(imageName: string): Promise<string>;
 }

--- a/src/static/static.service.ts
+++ b/src/static/static.service.ts
@@ -20,6 +20,10 @@ export class StaticService {
     return this.staticService.getImage(imageName);
   }
 
+  async getImageBuffer(imageName: string): Promise<Buffer | null> {
+    return this.staticService.getImageBuffer(imageName);
+  }
+
   async deleteImage(imageName: string): Promise<boolean> {
     return this.staticService.deleteImage(imageName);
   }


### PR DESCRIPTION
## Problem

"Download images for selected rows" fails on S3-backed deployments. The zip is assembled in the browser, so every image is fetched — and `GET /images/:fileName` answers with a redirect to a pre-signed S3 URL, which carries no CORS headers:

```
Access to fetch at 'https://<bucket>.s3.<region>.amazonaws.com/WRHMNG…screenshot.png?X-Amz-…'
(redirected from 'https://<vrt>/images/WRHMNG…screenshot.png') from origin 'https://<vrt>'
has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present
```

An `<img>` tag is not subject to this, which is why the images keep displaying while the download silently fails.

## Change

Add `GET /images/:fileName/download`, which reads the bytes through the storage service and answers from the API's own origin (CORS is already enabled there), with `Content-Type: image/png` and `Content-Disposition: attachment`. Missing images answer 404 instead of a redirect to nothing.

The existing redirect route is untouched, so displaying images still bypasses the API and image traffic keeps going straight to storage — only the explicit, user-initiated download passes through.

Also adds `getImageBuffer` to the `Static` interface (HDD + S3) as the primitive for this, and reuses it in `AWSS3Service.getImage`.

## Verification

Built and run against the local stack (HDD storage) as a second API instance:

```
GET /images/<name>            -> 302 (unchanged)
GET /images/<name>/download   -> 200, Content-Type: image/png,
                                 Content-Disposition: attachment; filename="<name>",
                                 Access-Control-Allow-Origin: *
                                 bytes byte-for-byte identical to the stored file
GET /images/missing.png/download -> 404 (with CORS headers)
```

Full jest suite passes. Frontend counterpart: Visual-Regression-Tracker/frontend#398 (this PR must ship first, or the button 404s).

Note: `getImageBuffer" also appears in #368; whichever merges first, the other rebases — the two additions are identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an image download endpoint.
  - Available images can be downloaded as PNG files with an appropriate filename.
  - Missing images return a clear 404 response.

- **Bug Fixes**
  - Improved handling of image retrieval and file-reading failures.
  - Invalid or path-containing filenames are rejected with a 400 response.
  - Prevented image requests from accessing files outside the configured image directory.
  - Storage and permission errors now surface appropriately instead of being treated as missing images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Merging

Merge this **before** #368: both touch the same four files under `src/static`, and #368 is already rebased on top of this branch, so in this order both merge with no conflicts.

Nothing to configure, and the frontend side (Visual-Regression-Tracker/frontend#398) falls back to the old redirect when this route is absent, so the two repos can be deployed in either order.
