### PR TITLE
perf: let the browser keep the screenshots it has already downloaded

### DIFF
--- a/src/static/aws/s3.service.spec.ts
+++ b/src/static/aws/s3.service.spec.ts
@@ -115,28 +115,83 @@ describe('AWSS3Service', () => {
   });
 
   describe('getImageUrl', () => {
+    // A browser caches by URL. Signing from the current instant produced a
+    // different URL on every request, so the bytes it had just downloaded
+    // could never be reused and every view of an image cost a fresh download.
+    const signingDateOfLastCall = (): Date => (getSignedUrl as jest.Mock).mock.calls.at(-1)[2].signingDate;
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
     it('returns a signed URL for the requested object', async () => {
       const service = new AWSS3Service();
       (getSignedUrl as jest.Mock).mockResolvedValue('https://signed-url');
 
       const result = await service.getImageUrl('image.png');
 
-      expect(GetObjectCommand).toHaveBeenCalledWith({
-        Bucket: 'vrt-bucket',
-        Key: 'image.png',
-      });
-      expect(getSignedUrl).toHaveBeenCalledWith(
-        (service as any).s3Client,
-        {
-          input: {
-            Bucket: 'vrt-bucket',
-            Key: 'image.png',
-          },
-          type: 'get',
-        },
-        { expiresIn: 3600 }
-      );
       expect(result).toBe('https://signed-url');
+      expect(GetObjectCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ Bucket: 'vrt-bucket', Key: 'image.png' })
+      );
+    });
+
+    it('hands out the same URL for an image asked for again soon after', async () => {
+      const service = new AWSS3Service();
+      (getSignedUrl as jest.Mock).mockResolvedValue('https://signed-url');
+      const nowSpy = jest.spyOn(Date, 'now');
+
+      nowSpy.mockReturnValue(Date.parse('2026-09-01T10:00:05Z'));
+      await service.getImageUrl('image.png');
+      const first = signingDateOfLastCall();
+
+      nowSpy.mockReturnValue(Date.parse('2026-09-01T10:42:31Z'));
+      await service.getImageUrl('image.png');
+
+      // asserted to be a real instant first: two undefineds are also equal
+      expect(first).toBeInstanceOf(Date);
+      expect(signingDateOfLastCall()).toEqual(first);
+    });
+
+    it('moves on to a new URL once the window has passed', async () => {
+      const service = new AWSS3Service();
+      (getSignedUrl as jest.Mock).mockResolvedValue('https://signed-url');
+      const nowSpy = jest.spyOn(Date, 'now');
+
+      nowSpy.mockReturnValue(Date.parse('2026-09-01T10:42:31Z'));
+      await service.getImageUrl('image.png');
+      const first = signingDateOfLastCall();
+
+      nowSpy.mockReturnValue(Date.parse('2026-09-01T11:00:01Z'));
+      await service.getImageUrl('image.png');
+
+      expect(signingDateOfLastCall()).not.toEqual(first);
+    });
+
+    // a URL handed out at the very end of a window must still be usable for a
+    // whole window afterwards, or the browser's cached copy outlives its URL
+    it('keeps a URL alive well past the window it was signed in', async () => {
+      const service = new AWSS3Service();
+      (getSignedUrl as jest.Mock).mockResolvedValue('https://signed-url');
+
+      await service.getImageUrl('image.png');
+
+      const { expiresIn, signingDate } = (getSignedUrl as jest.Mock).mock.calls.at(-1)[2];
+      const livesUntil = signingDate.getTime() + expiresIn * 1000;
+      expect(livesUntil - Date.now()).toBeGreaterThanOrEqual(3600 * 1000);
+    });
+
+    // S3 answers with no cache headers of its own, so a stable URL alone still
+    // leaves the browser guessing whether it may keep the bytes
+    it('asks S3 to answer with a cache header', async () => {
+      const service = new AWSS3Service();
+      (getSignedUrl as jest.Mock).mockResolvedValue('https://signed-url');
+
+      await service.getImageUrl('image.png');
+
+      expect(GetObjectCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ ResponseCacheControl: expect.stringContaining('max-age=') })
+      );
     });
   });
 

--- a/src/static/aws/s3.service.spec.ts
+++ b/src/static/aws/s3.service.spec.ts
@@ -173,12 +173,18 @@ describe('AWSS3Service', () => {
     it('keeps a URL alive well past the window it was signed in', async () => {
       const service = new AWSS3Service();
       (getSignedUrl as jest.Mock).mockResolvedValue('https://signed-url');
+      // The worst case, when the least life is left: minted at the last second
+      // of a window. Pinned rather than read live, or a run that straddles the
+      // hour boundary asks the clock on the far side of it and sees a shorter
+      // life than the URL actually has.
+      const lastSecondOfWindow = Date.parse('2026-09-01T10:59:59Z');
+      jest.spyOn(Date, 'now').mockReturnValue(lastSecondOfWindow);
 
       await service.getImageUrl('image.png');
 
       const { expiresIn, signingDate } = (getSignedUrl as jest.Mock).mock.calls.at(-1)[2];
       const livesUntil = signingDate.getTime() + expiresIn * 1000;
-      expect(livesUntil - Date.now()).toBeGreaterThanOrEqual(3600 * 1000);
+      expect(livesUntil - lastSecondOfWindow).toBeGreaterThanOrEqual(3600 * 1000);
     });
 
     // S3 answers with no cache headers of its own, so a stable URL alone still

--- a/src/static/aws/s3.service.ts
+++ b/src/static/aws/s3.service.ts
@@ -12,6 +12,10 @@ import { Readable } from 'stream';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { generateNewImageName } from '../utils';
 
+// How long one pre-signed URL is reused before a new one is minted. Also the
+// lifetime S3 is asked to advertise on the object itself.
+export const URL_WINDOW_SECONDS = 3600;
+
 export class AWSS3Service implements Static {
   private readonly logger: Logger = new Logger(AWSS3Service.name);
   private readonly AWS_S3_BUCKET_NAME = process.env.AWS_S3_BUCKET_NAME;
@@ -87,12 +91,34 @@ export class AWSS3Service implements Static {
     }
   }
 
+  /**
+   * A pre-signed URL for the object, stable for the length of a window.
+   *
+   * A browser caches by URL. Signing from the current instant gave every
+   * request a different URL, so the bytes it had just downloaded could never be
+   * reused: reopening a screen, or stepping back one, paid for the whole image
+   * again. Signing from the start of a fixed window instead makes every request
+   * inside that window produce the very same URL, which a cache can hit.
+   *
+   * The signature is given twice the window to live, so a URL handed out at the
+   * last second of one window is still good for a whole window afterwards.
+   *
+   * `ResponseCacheControl` makes S3 answer with a cache header of its own —
+   * without it a stable URL still leaves the browser guessing, since the bucket
+   * sets none. An image name is unique per upload and its bytes never change,
+   * so the only thing bounding the lifetime is the signature.
+   */
   async getImageUrl(imageName: string): Promise<string> {
     const command = new GetObjectCommand({
       Bucket: `${this.AWS_S3_BUCKET_NAME}`,
       Key: imageName,
+      ResponseCacheControl: `private, max-age=${URL_WINDOW_SECONDS}`,
     });
-    return getSignedUrl(this.s3Client, command, { expiresIn: 3600 });
+    const windowMs = URL_WINDOW_SECONDS * 1000;
+    return getSignedUrl(this.s3Client, command, {
+      expiresIn: URL_WINDOW_SECONDS * 2,
+      signingDate: new Date(Math.floor(Date.now() / windowMs) * windowMs),
+    });
   }
 
   async deleteImage(imageName: string): Promise<boolean> {

--- a/src/static/static.controller.spec.ts
+++ b/src/static/static.controller.spec.ts
@@ -4,13 +4,13 @@ import { Response } from 'express';
 import { StaticController } from './static.controller';
 import { StaticService } from './static.service';
 
-const initController = async (getImageBufferMock = jest.fn()) => {
+const initController = async (getImageBufferMock = jest.fn(), getImageUrlMock = jest.fn()) => {
   const module: TestingModule = await Test.createTestingModule({
     controllers: [StaticController],
     providers: [
       {
         provide: StaticService,
-        useValue: { getImageBuffer: getImageBufferMock, getImageUrl: jest.fn() },
+        useValue: { getImageBuffer: getImageBufferMock, getImageUrl: getImageUrlMock },
       },
     ],
   }).compile();
@@ -19,8 +19,8 @@ const initController = async (getImageBufferMock = jest.fn()) => {
 };
 
 const responseMock = () => {
-  const res = { set: jest.fn(), send: jest.fn() };
-  return res as unknown as Response & { set: jest.Mock; send: jest.Mock };
+  const res = { set: jest.fn(), send: jest.fn(), redirect: jest.fn() };
+  return res as unknown as Response & { set: jest.Mock; send: jest.Mock; redirect: jest.Mock };
 };
 
 describe('download', () => {
@@ -58,4 +58,31 @@ describe('download', () => {
       expect(getImageBufferMock).not.toHaveBeenCalled();
     }
   );
+});
+
+describe('getUrlAndRedirect', () => {
+  // Without this the browser asks the API for a location on every single view.
+  // Storage then hands back a freshly signed, and therefore different, URL, and
+  // the image it already holds is dead weight — every view a fresh download.
+  it('lets the browser reuse the redirect it was given', async () => {
+    const getImageUrlMock = jest.fn().mockResolvedValueOnce('https://storage/image.png');
+    const controller = await initController(jest.fn(), getImageUrlMock);
+    const res = responseMock();
+
+    await controller.getUrlAndRedirect('image.png', res);
+
+    expect(res.set).toHaveBeenCalledWith('Cache-Control', expect.stringContaining('max-age='));
+    expect(res.redirect).toHaveBeenCalledWith('https://storage/image.png');
+  });
+
+  // the redirect may not outlive the URL it points at
+  it('stops reusing the redirect before the signed URL can expire', async () => {
+    const controller = await initController(jest.fn(), jest.fn().mockResolvedValueOnce('https://storage/image.png'));
+    const res = responseMock();
+
+    await controller.getUrlAndRedirect('image.png', res);
+
+    const [, value] = res.set.mock.calls.find(([header]) => header === 'Cache-Control');
+    expect(Number(/max-age=(\d+)/.exec(value)[1])).toBeLessThan(3600);
+  });
 });

--- a/src/static/static.controller.ts
+++ b/src/static/static.controller.ts
@@ -4,6 +4,10 @@ import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { basename } from 'path';
 import { StaticService } from './static.service';
 
+// Shorter than the window a signed URL is minted for (URL_WINDOW_SECONDS), so a
+// cached redirect always still points at a URL that works.
+const REDIRECT_MAX_AGE_SECONDS = 3000;
+
 @ApiTags('images')
 @Controller('images')
 export class StaticController {
@@ -15,6 +19,13 @@ export class StaticController {
   async getUrlAndRedirect(@Param('fileName') fileName: string, @Res() res: Response) {
     try {
       const url = await this.staticService.getImageUrl(fileName);
+      // The redirect has to be reusable too, or the browser comes back here for
+      // a location on every single view — and a storage that signs its URLs
+      // hands back a different one each time, making the copy the browser
+      // already holds worthless. Kept well inside the signature's life so the
+      // redirect can never outlive what it points at. Private, because a signed
+      // URL is an access grant and has no business in a shared cache.
+      res.set('Cache-Control', `private, max-age=${REDIRECT_MAX_AGE_SECONDS}`);
       res.redirect(url);
     } catch (error) {
       this.logger.error('Error fetching file from S3:' + fileName, error);


### PR DESCRIPTION
On an S3 deployment nothing about an image is cacheable today. Every view of every screenshot costs a round trip through the API and a full download from the bucket, even when the browser downloaded those exact bytes a second earlier.

Three things had to be true for caching to work, and none of them were:

| | before | after |
|---|---|---|
| the URL | freshly signed per request, so different every time | stable for a window |
| the object | bucket sets no cache headers | `ResponseCacheControl` on the signed request |
| the redirect | no cache headers, so re-requested per view | cacheable, under the signature's life |

Fixing any one alone changes nothing — a stable URL is useless if the browser asks the API for a new one each time, and a cacheable redirect is useless if it points somewhere new.

## The URL

`getSignedUrl` was called with no `signingDate`, so the signature was minted from the current instant and every request produced a different URL. A browser caches by URL: the bytes it had downloaded a moment earlier could never be hit.

The signature is now minted from the start of a fixed window, so every request inside that window yields the same URL. `expiresIn` is twice the window, so a URL handed out at the last second of one is still good for a whole window afterwards — the browser's copy can never outlive its own URL.

## The object

S3 returns whatever cache headers the object carries, and the bucket sets none. `ResponseCacheControl` on the pre-signed `GetObject` makes S3 advertise a lifetime on the response itself. An image name is unique per upload and its bytes are never rewritten, so nothing but the signature bounds it.

## The redirect

`res.redirect()` sets no cache headers, and a 302 is not heuristically cacheable, so the browser came back for a location on every single view. It is now cacheable for less than the signing window, so a cached redirect can never point at an expired URL. `private`, because a pre-signed URL is an access grant and has no business in a shared cache.

## HDD deployments

Unaffected in substance — `getImageUrl` there returns a local path that the static middleware already serves with a year of caching — but they get the reusable redirect too.

## Deploy ordering

Worth knowing alongside frontend #402, which prefetches the neighbouring runs' screenshots. Until this change is out, that prefetch downloads an image and the browser is then made to download it a second time when the reviewer actually opens the screen, because the second request mints a different URL. With this change the prefetch lands in the cache and the open is free.

## Tests

Six, each watched failing first: URL stability inside a window, a new URL once it passes, the signature outliving the window it was minted in, the cache header on the object, the cacheable redirect, and the redirect's lifetime staying under the signature's.

One of them passed on the first run for the wrong reason — `signingDate` was `undefined` on both calls and two undefineds compare equal — so it now asserts the value is a real instant before comparing.

All 34 backend spec files pass. (The full parallel run trips over a missing Prisma engine binary in the sandbox, identically on `master`, so specs were run one at a time.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image redirects now support private browser caching for faster repeat access.
  * Signed image URLs remain stable within a defined signing window and rotate automatically afterward.
  * Image responses include cache metadata aligned with signed URL expiration.

* **Bug Fixes**
  * Improved image URL caching reduces unnecessary regeneration while preserving secure expiration.
  * Redirect responses now advertise a cache lifetime that remains within the signed URL validity period.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->