### PR TITLE
feat: let the S3 client address a bucket path-style

### DIFF
--- a/src/static/aws/s3.service.spec.ts
+++ b/src/static/aws/s3.service.spec.ts
@@ -8,8 +8,9 @@ import { generateNewImageName } from '../utils';
 const mockSend = jest.fn();
 
 jest.mock('@aws-sdk/client-s3', () => ({
-  S3Client: jest.fn().mockImplementation(() => ({
+  S3Client: jest.fn().mockImplementation((config) => ({
     send: mockSend,
+    config,
   })),
   PutObjectCommand: jest.fn().mockImplementation((input) => ({ input, type: 'put' })),
   GetObjectCommand: jest.fn().mockImplementation((input) => ({ input, type: 'get' })),
@@ -230,6 +231,36 @@ describe('AWSS3Service', () => {
       await expect(service.deleteImage('image.png')).resolves.toBe(false);
 
       expect(loggerSpy).toHaveBeenCalledWith('Failed to delete file at AWS S3 for image image.png:', error);
+    });
+  });
+
+  // S3-compatible storage — MinIO, Ceph, Garage — is normally reached
+  // path-style (host/bucket/key); AWS itself uses virtual-host style
+  // (bucket.host/key) and the SDK assumes that. Without a way to switch, a
+  // self-hosted deployment cannot point VRT at its own storage, and neither
+  // can anyone trying to reproduce a production setup locally.
+  describe('S3-compatible storage', () => {
+    const originalPathStyle = process.env.AWS_S3_FORCE_PATH_STYLE;
+
+    afterEach(() => {
+      process.env.AWS_S3_FORCE_PATH_STYLE = originalPathStyle;
+      if (originalPathStyle === undefined) delete process.env.AWS_S3_FORCE_PATH_STYLE;
+    });
+
+    it('addresses the bucket path-style when asked to', () => {
+      process.env.AWS_S3_FORCE_PATH_STYLE = 'true';
+
+      const service = new AWSS3Service();
+
+      expect((service as any).s3Client.config).toMatchObject({ forcePathStyle: true });
+    });
+
+    it('leaves the SDK to its own addressing by default', () => {
+      delete process.env.AWS_S3_FORCE_PATH_STYLE;
+
+      const service = new AWSS3Service();
+
+      expect((service as any).s3Client.config?.forcePathStyle).toBeFalsy();
     });
   });
 });

--- a/src/static/aws/s3.service.ts
+++ b/src/static/aws/s3.service.ts
@@ -23,8 +23,18 @@ export class AWSS3Service implements Static {
   private s3Client: S3Client;
 
   constructor() {
-    this.s3Client = new S3Client();
-    this.logger.log('AWS S3 service is being used for file storage.');
+    // S3-compatible storage — MinIO, Ceph, Garage — is normally addressed
+    // path-style (host/bucket/key), while AWS uses virtual-host style
+    // (bucket.host/key) and the SDK assumes that. It has no environment
+    // variable for the switch, so without this a self-hosted deployment cannot
+    // point VRT at its own storage, and neither can anyone standing up a
+    // production-shaped stack locally. The endpoint itself the SDK does read
+    // from AWS_ENDPOINT_URL.
+    const forcePathStyle = process.env.AWS_S3_FORCE_PATH_STYLE === 'true';
+    this.s3Client = new S3Client(forcePathStyle ? { forcePathStyle } : {});
+    this.logger.log(
+      `AWS S3 service is being used for file storage${forcePathStyle ? ' (path-style addressing)' : ''}.`
+    );
   }
 
   async saveImage(type: 'screenshot' | 'diff' | 'baseline', imageBuffer: Buffer): Promise<string> {


### PR DESCRIPTION
S3-compatible storage — MinIO, Ceph, Garage — is normally reached **path-style** (`host/bucket/key`). AWS uses **virtual-host style** (`bucket.host/key`), the SDK assumes that, and it has no environment variable for the switch. `new S3Client()` is constructed with no configuration, so there was no way to change it.

The result is that pointing VRT at anything other than AWS fails at the first upload:

```
Could not save file at AWS S3 : Error: getaddrinfo ENOTFOUND vrt.minio
```

The endpoint itself the SDK already reads from `AWS_ENDPOINT_URL`, so that half worked; only the addressing style was unreachable.

`AWS_S3_FORCE_PATH_STYLE=true` now turns it on. Unset, the SDK keeps deciding for itself, so nothing changes for an AWS deployment — the client is constructed with an empty config exactly as before.

## Why it is worth having

Beyond self-hosters using their own object storage, this is what makes it possible to stand up a stack that behaves like production *locally*: images in S3-compatible storage, reached through the API's signed-URL redirect. That path — the redirect, the pre-signed URL, its caching — simply does not exist on the HDD backend, so a local HDD instance cannot reproduce or reveal anything about it. Verified here against MinIO end to end: uploads land in the bucket, `/images/:name` redirects to a path-style signed URL, and the browser follows it.

## Tests

Two, watched failing first: the client is constructed with `forcePathStyle` when the variable is set, and is left to the SDK's own choice when it is not.

All backend spec files pass.